### PR TITLE
Fix bug with required non-empty parameter

### DIFF
--- a/src/Mapping/Parameter/FloatTypeMapper.php
+++ b/src/Mapping/Parameter/FloatTypeMapper.php
@@ -7,10 +7,14 @@ class FloatTypeMapper extends AbstractTypeMapper
 
 	/**
 	 * @param mixed $value
-	 * @return int
+	 * @return float|null
 	 */
 	public function normalize($value)
 	{
+		if ($value === null) {
+			return $value;
+		}
+
 		return floatval($value);
 	}
 

--- a/src/Mapping/Parameter/IntegerTypeMapper.php
+++ b/src/Mapping/Parameter/IntegerTypeMapper.php
@@ -7,10 +7,14 @@ class IntegerTypeMapper extends AbstractTypeMapper
 
 	/**
 	 * @param mixed $value
-	 * @return int
+	 * @return int|null
 	 */
 	public function normalize($value)
 	{
+		if ($value === null) {
+			return $value;
+		}
+
 		return intval($value);
 	}
 

--- a/src/Mapping/Parameter/StringTypeMapper.php
+++ b/src/Mapping/Parameter/StringTypeMapper.php
@@ -7,10 +7,14 @@ class StringTypeMapper extends AbstractTypeMapper
 
 	/**
 	 * @param mixed $value
-	 * @return int
+	 * @return string|null
 	 */
 	public function normalize($value)
 	{
+		if ($value === null) {
+			return $value;
+		}
+
 		return strval($value);
 	}
 

--- a/src/Mapping/RequestParameterMapping.php
+++ b/src/Mapping/RequestParameterMapping.php
@@ -82,6 +82,13 @@ class RequestParameterMapping
 					// Obtain request parameter values
 					$value = $requestParameters[$parameter->getName()];
 
+					if ($value === null && $parameter->isRequired()) {
+						throw new InvalidStateException(sprintf('Parameter "%s" should be provided in request attributes', $parameter->getName()));
+					}
+					if ($value === '' && !$parameter->isAllowEmpty()) {
+						throw new InvalidStateException(sprintf('Parameter "%s" should not be empty', $parameter->getName()));
+					}
+
 					// Normalize value
 					$normalizedValue = $mapper->normalize($value);
 
@@ -102,6 +109,13 @@ class RequestParameterMapping
 
 					// Obtain request parameter values
 					$value = $cookieParams[$parameter->getName()];
+
+					if ($value === null && $parameter->isRequired()) {
+						throw new InvalidStateException(sprintf('Parameter "%s" should be provided in request attributes', $parameter->getName()));
+					}
+					if ($value === '' && !$parameter->isAllowEmpty()) {
+						throw new InvalidStateException(sprintf('Parameter "%s" should not be empty', $parameter->getName()));
+					}
 
 					// Normalize value
 					$normalizedValue = $mapper->normalize($value);
@@ -128,6 +142,10 @@ class RequestParameterMapping
 
 					// Normalize value
 					foreach ($values as $index => $value) {
+						if ($value === '' && !$parameter->isAllowEmpty()) {
+							throw new InvalidStateException(sprintf('Parameter "%s" should not be empty', $parameter->getName()));
+						}
+
 						$normalizedValues[$index] = $mapper->normalize($value);
 					}
 

--- a/tests/cases/Mapping/Parameter/FloatTypeMapper.php
+++ b/tests/cases/Mapping/Parameter/FloatTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test: Mapping\Parameter\FloatTypeMapper
+ */
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+use Apitte\Core\Mapping\Parameter\FloatTypeMapper;
+use Tester\Assert;
+
+final class TestFloatTypeMapper extends Tester\TestCase
+{
+	public function testNormalize()
+	{
+		$floatTypeMapper=new FloatTypeMapper;
+
+		Assert::same(null, $floatTypeMapper->normalize(null));
+		Assert::same(0.0, $floatTypeMapper->normalize(0));
+		Assert::same(0.33, $floatTypeMapper->normalize('0.33'));
+		Assert::same(1.99, $floatTypeMapper->normalize('1.99'));
+		Assert::same(-10.0, $floatTypeMapper->normalize('-10'));
+	}
+}
+
+(new TestFloatTypeMapper)->run();

--- a/tests/cases/Mapping/Parameter/IntegerTypeMapper.php
+++ b/tests/cases/Mapping/Parameter/IntegerTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test: Mapping\Parameter\IntegerTypeMapper
+ */
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+use Apitte\Core\Mapping\Parameter\IntegerTypeMapper;
+use Tester\Assert;
+
+final class TestIntegerTypeMapper extends Tester\TestCase
+{
+	public function testNormalize()
+	{
+		$floatTypeMapper = new IntegerTypeMapper;
+
+		Assert::same(NULL, $floatTypeMapper->normalize(NULL));
+		Assert::same(0, $floatTypeMapper->normalize(0));
+		Assert::same(0, $floatTypeMapper->normalize('0.33'));
+		Assert::same(1, $floatTypeMapper->normalize('1.99'));
+		Assert::same(-10, $floatTypeMapper->normalize('-10'));
+	}
+}
+
+(new TestIntegerTypeMapper)->run();

--- a/tests/cases/Mapping/Parameter/StringTypeMapper.php
+++ b/tests/cases/Mapping/Parameter/StringTypeMapper.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test: Mapping\Parameter\StringTypeMapper
+ */
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+use Apitte\Core\Mapping\Parameter\StringTypeMapper;
+use Tester\Assert;
+
+final class TestStringTypeMapper extends Tester\TestCase
+{
+	public function testNormalize()
+	{
+		$floatTypeMapper = new StringTypeMapper;
+
+		Assert::same(NULL, $floatTypeMapper->normalize(NULL));
+		Assert::same('0', $floatTypeMapper->normalize(0));
+		Assert::same('0.33', $floatTypeMapper->normalize(0.33));
+		Assert::same('1.99', $floatTypeMapper->normalize(1.99));
+		Assert::same('-10', $floatTypeMapper->normalize(-10));
+	}
+}
+
+(new TestStringTypeMapper)->run();

--- a/tests/cases/Mapping/RequestParameterMapping.phpt
+++ b/tests/cases/Mapping/RequestParameterMapping.phpt
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * Test: Mapping\RequestParameterMapping
+ */
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
+use Apitte\Core\Http\RequestAttributes;
+use Apitte\Core\Mapping\Parameter\IntegerTypeMapper;
+use Apitte\Core\Mapping\Parameter\FloatTypeMapper;
+use Apitte\Core\Mapping\Parameter\StringTypeMapper;
+use Apitte\Core\Mapping\RequestParameterMapping;
+use Apitte\Core\Schema\Endpoint;
+use Apitte\Core\Schema\EndpointParameter;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\ServerRequest;
+use Tester\Assert;
+
+final class TestRequestParameterMapping extends Tester\TestCase
+{
+	/**
+	 * @var RequestParameterMapping
+	 */
+	private $requestParameterMapping;
+	/**
+	 * @var ApiRequest
+	 */
+	private $request;
+	/**
+	 * @var ApiResponse
+	 */
+	private $response;
+
+	protected function setUp()
+	{
+		$this->requestParameterMapping = new RequestParameterMapping;
+
+		$this->requestParameterMapping->addMapper('string', new StringTypeMapper);
+		$this->requestParameterMapping->addMapper('int', new IntegerTypeMapper);
+		$this->requestParameterMapping->addMapper('float', new FloatTypeMapper);
+
+		$this->request = new ApiRequest(
+			new ServerRequest(
+				'GET',
+				'/'
+			)
+		);
+		$this->response = new ApiResponse(new Response);
+	}
+
+	public function testIntInPath()
+	{
+		$endpoint = new Endpoint;
+
+		$idEndpointParameter = new EndpointParameter;
+		$idEndpointParameter->setName('id');
+		$idEndpointParameter->setType('int');
+		$idEndpointParameter->setIn($idEndpointParameter::IN_PATH);
+		$idEndpointParameter->setRequired(false);
+		$idEndpointParameter->setAllowEmpty(true);
+
+		$endpoint->addParameter($idEndpointParameter);
+
+		$request = $this->request
+			->withAttribute(RequestAttributes::ATTR_ENDPOINT, $endpoint)
+			->withAttribute(RequestAttributes::ATTR_PARAMETERS, [
+				'id' => null
+			]);
+
+		// ---- test optional parameter
+
+		$notRequiredIdResponse = $this->requestParameterMapping->map(
+			$request, $this->response
+		);
+
+		Assert::null($notRequiredIdResponse->getAttribute(RequestAttributes::ATTR_PARAMETERS)['id']);
+
+		// ---- test throw missing parameter
+
+		$idEndpointParameter->setRequired(true);
+
+		Assert::throws(function () use ($request) {
+			$this->requestParameterMapping->map($request, $this->response);
+		}, \Apitte\Core\Exception\Logical\InvalidStateException::class,
+		   'Parameter "id" should be provided in request attributes'
+		);
+
+		// ---- test correct map int parameter
+
+		$requestWithId = $request->withAttribute(RequestAttributes::ATTR_PARAMETERS, [
+			'id' => '10',
+		]);
+
+		$requiredIdResponse = $this->requestParameterMapping->map($requestWithId, $this->response);
+
+		Assert::true(
+			array_key_exists(
+				'id',
+				$requiredIdResponse->getAttribute(RequestAttributes::ATTR_PARAMETERS)
+			)
+		);
+		Assert::same(10, $requiredIdResponse->getAttribute(RequestAttributes::ATTR_PARAMETERS)['id']);
+
+		// ---- test throw empty parameter
+
+		$requestWithEmptyId = $request->withAttribute(RequestAttributes::ATTR_PARAMETERS, [
+			'id' => '',
+		]);
+		$idEndpointParameter->setAllowEmpty(false);
+
+		Assert::throws(function () use ($requestWithEmptyId) {
+			$this->requestParameterMapping->map($requestWithEmptyId, $this->response);
+		}, \Apitte\Core\Exception\Logical\InvalidStateException::class,
+		   'Parameter "id" should not be empty'
+		);
+	}
+
+	public function testFloatInQuery()
+	{
+		$endpoint = new Endpoint;
+
+		$scoreEndpointParameter = new EndpointParameter;
+		$scoreEndpointParameter->setName('score');
+		$scoreEndpointParameter->setType('float');
+		$scoreEndpointParameter->setIn($scoreEndpointParameter::IN_QUERY);
+		$scoreEndpointParameter->setRequired(false);
+		$scoreEndpointParameter->setAllowEmpty(true);
+
+		$endpoint->addParameter($scoreEndpointParameter);
+
+		$request = $this->request
+			->withAttribute(RequestAttributes::ATTR_ENDPOINT, $endpoint)
+			->withAttribute(RequestAttributes::ATTR_PARAMETERS, [
+				'score' => null,
+			]);
+
+		$noScoreResponse = $this->requestParameterMapping->map($request, $this->response);
+
+		Assert::equal(['score' => null], $noScoreResponse->getAttribute(RequestAttributes::ATTR_PARAMETERS));
+
+		$requestWithIdAndScore = $request->withAttribute(
+			RequestAttributes::ATTR_PARAMETERS,
+			[
+				'score' => '3.33',
+			]
+		);
+
+		$scoreResponse = $this->requestParameterMapping->map(
+			$requestWithIdAndScore,
+			$this->response
+		);
+
+		Assert::equal(
+			[
+				'score' => 3.33,
+			],
+			$scoreResponse->getAttribute(RequestAttributes::ATTR_PARAMETERS)
+		);
+
+		$scoreEndpointParameter->setRequired(true);
+
+		Assert::throws(function () use ($request) {
+			$this->requestParameterMapping->map($request, $this->response);
+		}, \Apitte\Core\Exception\Logical\InvalidStateException::class,
+		   'Parameter "score" should be provided in request attributes'
+		);
+	}
+
+	public function testStringInCookie()
+	{
+		$endpoint = new Endpoint;
+
+		$sessionEndpointParameter = new EndpointParameter;
+		$sessionEndpointParameter->setName('session');
+		$sessionEndpointParameter->setType('string');
+		$sessionEndpointParameter->setIn($sessionEndpointParameter::IN_COOKIE);
+		$sessionEndpointParameter->setRequired(false);
+		$sessionEndpointParameter->setAllowEmpty(false);
+
+		$endpoint->addParameter($sessionEndpointParameter);
+
+		$request = $this->request
+			->withAttribute(RequestAttributes::ATTR_ENDPOINT, $endpoint)
+			->withAttribute(RequestAttributes::ATTR_PARAMETERS, [])
+			->withCookieParams(
+				[
+					'session' => null,
+				]
+			);
+
+		$responseWithoutCookie=$this->requestParameterMapping->map($request, $this->response);
+		Assert::equal(['session' => null], $responseWithoutCookie->getCookieParams());
+
+		$requestWithEmptyCookie = $request->withCookieParams(
+			[
+				'session' => '',
+			]
+		);
+
+		Assert::throws(function () use ($requestWithEmptyCookie) {
+			$this->requestParameterMapping->map($requestWithEmptyCookie, $this->response);
+		}, \Apitte\Core\Exception\Logical\InvalidStateException::class,
+		   'Parameter "session" should not be empty'
+		);
+
+		$requestWithCookie = $request->withCookieParams(
+			[
+				'session' => 'bar-baz-key',
+			]
+		);
+
+		$cookieResponse = $this->requestParameterMapping->map(
+			$requestWithCookie,
+			$this->response
+		);
+
+		Assert::equal(['session' => 'bar-baz-key'], $cookieResponse->getCookieParams());
+	}
+
+	public function testStringInHeader()
+	{
+		$endpoint = new Endpoint;
+
+		$authEndpointParameter = new EndpointParameter;
+		$authEndpointParameter->setName('auth');
+		$authEndpointParameter->setType('string');
+		$authEndpointParameter->setIn($authEndpointParameter::IN_HEADER);
+		$authEndpointParameter->setRequired(true);
+		$authEndpointParameter->setAllowEmpty(false);
+
+		$endpoint->addParameter($authEndpointParameter);
+
+		$request = $this->request
+			->withAttribute(RequestAttributes::ATTR_ENDPOINT, $endpoint)
+			->withAttribute(RequestAttributes::ATTR_PARAMETERS, []);
+
+		$requestWithEmptyHeader = $request->withHeader(
+			'auth',
+			[
+				'some',
+				'',
+			]
+		);
+
+		Assert::throws(function () use ($requestWithEmptyHeader) {
+			$this->requestParameterMapping->map($requestWithEmptyHeader, $this->response);
+		}, \Apitte\Core\Exception\Logical\InvalidStateException::class,
+		   'Parameter "auth" should not be empty'
+		);
+
+		$requestWithHeader = $request->withHeader(
+			'auth',
+			[
+				'some',
+				'other',
+			]
+		);
+
+		$headerResponse = $this->requestParameterMapping->map($requestWithHeader, $this->response);
+
+		Assert::equal(
+			[
+				'some',
+				'other',
+			],
+			$headerResponse->getHeader('auth')
+		);
+	}
+}
+
+(new TestRequestParameterMapping)->run();


### PR DESCRIPTION
This PR add possibility to pass NULL value through `Mapping/Parameter/*TypeMapper.php`. It is needed for work with allow-empty parameters, there is a difference when there is passed an empty parameter and not passed (NULL).

And also add validation in 
the RequestParameterMapping for passed parameters with respect to the allow-empty configuration.

On not properly defined configuration it can be a BC break.