### PR TITLE
Fix Endpoint hasTag behavior when no value given

### DIFF
--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -217,7 +217,7 @@ final class Endpoint
 
 	public function hasTag(string $name): bool
 	{
-		return isset($this->tags[$name]);
+		return array_key_exists($name, $this->tags);
 	}
 
 	/**

--- a/tests/cases/Schema/Endpoint.phpt
+++ b/tests/cases/Schema/Endpoint.phpt
@@ -101,3 +101,13 @@ test(function (): void {
 
 	Assert::same(['p1' => $p1, 'p2' => $p2], $endpoint->getParametersByIn(EndpointParameter::IN_COOKIE));
 });
+
+test(function (): void {
+	$handler = new EndpointHandler('class', 'method');
+
+	$endpoint = new Endpoint($handler);
+
+	$endpoint->addTag('t1');
+
+	Assert::true($endpoint->hasTag('t1'));
+});


### PR DESCRIPTION
When a value of an item in array is null, isset returns false. 
A default value of a tag is null, but the tag itself exists, so hasTag method should return true in this case.