### PR TITLE
Fix suffix matching, escape them and add some tests to ensure it works

### DIFF
--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -327,10 +327,18 @@ final class Endpoint
 		}
 
 		if ($suffixes) {
-			return sprintf('#%s(?:%s)?$/?\z#A', $rawPattern, implode('|', $suffixes));
-		} else {
-			return sprintf('#%s$/?\z#A', $rawPattern);
+			return sprintf(
+				'#%s' . // Always start with raw pattern
+				'(?:%s)?$#', // Optionally contains dot followed by one of suffixes
+				$rawPattern,
+				implode('|', $suffixes)
+			);
 		}
+
+		return sprintf(
+			'#%s$#', // Exactly match raw pattern
+			$rawPattern
+		);
 	}
 
 	public function getRequestMapper(): ?EndpointRequestMapper

--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -329,7 +329,7 @@ final class Endpoint
 		if ($suffixes) {
 			return sprintf(
 				'#%s' . // Always start with raw pattern
-				'(?:%s)?$#', // Optionally contains dot followed by one of suffixes
+				'(%s)?$#U', // Optionally followed by one of suffixes
 				$rawPattern,
 				implode('|', array_map('preg_quote', $suffixes))
 			);

--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -331,7 +331,7 @@ final class Endpoint
 				'#%s' . // Always start with raw pattern
 				'(?:%s)?$#', // Optionally contains dot followed by one of suffixes
 				$rawPattern,
-				implode('|', $suffixes)
+				implode('|', array_map('preg_quote', $suffixes))
 			);
 		}
 

--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -310,7 +310,7 @@ final class Endpoint
 
 	protected function generatePattern(): string
 	{
-		$rawPattern = $this->getAttribute('pattern', null);
+		$rawPattern = $this->getAttribute('pattern');
 
 		if ($rawPattern === null) {
 			throw new InvalidStateException('Pattern attribute is required');

--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -308,7 +308,7 @@ final class Endpoint
 		return Arrays::get($this->metadata, $key, $default);
 	}
 
-	protected function generatePattern(): string
+	private function generatePattern(): string
 	{
 		$rawPattern = $this->getAttribute('pattern');
 

--- a/tests/cases/DI/ApiExtension.phpt
+++ b/tests/cases/DI/ApiExtension.phpt
@@ -57,7 +57,7 @@ test(function (): void {
 	Assert::count(3, $schema->getEndpoints());
 	Assert::equal(['GET'], $schema->getEndpoints()[0]->getMethods());
 	Assert::equal('/api/v1/foobar/baz1', $schema->getEndpoints()[0]->getMask());
-	Assert::equal('#/api/v1/foobar/baz1$/?\z#A', $schema->getEndpoints()[0]->getPattern());
+	Assert::equal('#/api/v1/foobar/baz1$#', $schema->getEndpoints()[0]->getPattern());
 	Assert::equal([], $schema->getEndpoints()[0]->getParameters());
 	Assert::equal(FoobarController::class, $schema->getEndpoints()[0]->getHandler()->getClass());
 	Assert::equal('baz1', $schema->getEndpoints()[0]->getHandler()->getMethod());

--- a/tests/cases/Schema/Serialization/ArrayHydrator.phpt
+++ b/tests/cases/Schema/Serialization/ArrayHydrator.phpt
@@ -95,7 +95,7 @@ test(function (): void {
 	Assert::same('/group1-path/group2-path/c1-path/m2-path', $endpoint1->getMask());
 	Assert::same('/group1-path/group2-path/c1-path/m2-path', $endpoint1->getAttribute('pattern'));
 	Assert::same(null, $endpoint1->getAttribute('missing'));
-	Assert::same('#/group1-path/group2-path/c1-path/m2-path$/?\z#A', $endpoint1->getPattern());
+	Assert::same('#/group1-path/group2-path/c1-path/m2-path$#', $endpoint1->getPattern());
 	Assert::same(null, $endpoint1->getDescription());
 	Assert::same([], $endpoint1->getParameters());
 	Assert::same([], $endpoint1->getNegotiations());
@@ -121,7 +121,7 @@ test(function (): void {
 	Assert::same('/group1-path/group2-path/c1-path/m3-path/{m3-p1}', $endpoint2->getMask());
 	Assert::same('/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)', $endpoint2->getAttribute('pattern'));
 	Assert::same(null, $endpoint2->getAttribute('missing'));
-	Assert::same('#/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)(?:json|xml)?$/?\z#A', $endpoint2->getPattern());
+	Assert::same('#/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)(?:json|xml)?$#', $endpoint2->getPattern());
 	Assert::same('m3-description', $endpoint2->getDescription());
 
 	Assert::same(null, $endpoint2->getRequestMapper());

--- a/tests/cases/Schema/Serialization/ArrayHydrator.phpt
+++ b/tests/cases/Schema/Serialization/ArrayHydrator.phpt
@@ -121,7 +121,7 @@ test(function (): void {
 	Assert::same('/group1-path/group2-path/c1-path/m3-path/{m3-p1}', $endpoint2->getMask());
 	Assert::same('/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)', $endpoint2->getAttribute('pattern'));
 	Assert::same(null, $endpoint2->getAttribute('missing'));
-	Assert::same('#/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)(?:json|xml)?$#', $endpoint2->getPattern());
+	Assert::same('#/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)(json|xml)?$#U', $endpoint2->getPattern());
 	Assert::same('m3-description', $endpoint2->getDescription());
 
 	Assert::same(null, $endpoint2->getRequestMapper());


### PR DESCRIPTION
`/foo/bar,debug` previously matched same as `/foo/bar`, now no match at all.
`/foo/bar/1.debug` with pattern `/foo/bar/{id}` matched id as `1.debug` instead of `1`, now it separates suffix correctly.