### PR TITLE
Strict code

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,12 +25,11 @@ parameters:
 		# Phpstan bug
 		- '#^Parameter \#1 \$function of function call_user_func_array expects callable\(\)\: mixed, array\(object, string\) given\.#'
 
-		# Phpstan don't know that variable could be set through catch
+		# Phpstan don't understand complex try-catch constructs
 		- message: '#^Strict comparison using !== between null and null will always evaluate to false\.$#'
 		  path: %currentWorkingDirectory%/src/Router/SimpleRouter.php
-
-		# Maybe will cause application fail - DecoratorManager::decorateResponse could return null, but DecoratedDispatcher is not always able to handle it.
-		- '#^Method Apitte\\Core\\Dispatcher\\DecoratedDispatcher::handle\(\) should return Psr\\Http\\Message\\ResponseInterface but returns Psr\\Http\\Message\\ResponseInterface\|null\.$#'
+		- message: '#^Method Apitte\\Core\\Dispatcher\\DecoratedDispatcher::handle\(\) should return Psr\\Http\\Message\\ResponseInterface but returns Psr\\Http\\Message\\ResponseInterface\|null\.$#'
+		  path: %currentWorkingDirectory%/src/Dispatcher/DecoratedDispatcher.php
 
 		# Maybe later - complicated to fix
 		- '#^.*should be contravariant with parameter.*$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,8 +35,6 @@ parameters:
 		- '#^.*should be contravariant with parameter.*$#'
 
 		# Missing strict comparison
-		- message: '#^.*string\|null given\.$#'
-		  path: %currentWorkingDirectory%/src/DI/Loader/DoctrineAnnotationLoader.php
 		- message: '#^Construct empty\(\) is not allowed. Use more strict comparison.$#'
 		  path: %currentWorkingDirectory%/src/Annotation
 		- '#^Only booleans are allowed in#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,6 +35,4 @@ parameters:
 		- '#^.*should be contravariant with parameter.*$#'
 
 		# Missing strict comparison
-		- message: '#^Construct empty\(\) is not allowed. Use more strict comparison.$#'
-		  path: %currentWorkingDirectory%/src/Annotation
 		- '#^Only booleans are allowed in#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,8 +33,6 @@ parameters:
 
 		# Maybe later - complicated to fix
 		- '#^.*should be contravariant with parameter.*$#'
-		- message: '#^.* Psr\\Http\\Message\\ServerRequestInterface\|null given\.$#'
-		  path: %currentWorkingDirectory%/src/Dispatcher/DecoratedDispatcher.php
 
 		# Missing strict comparison
 		- message: '#^.*string\|null given\.$#'

--- a/src/Annotation/Controller/ControllerId.php
+++ b/src/Annotation/Controller/ControllerId.php
@@ -20,19 +20,16 @@ final class ControllerId
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @ControllerId given');
-			}
-			$this->name = $values['value'];
-		} elseif (isset($values['name'])) {
-			if (empty($values['name'])) {
-				throw new AnnotationException('Empty @ControllerId given');
-			}
-			$this->name = $values['name'];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @ControllerId given');
 		}
+
+		$value = $values['value'];
+		if ($value === null || $value === '') {
+			throw new AnnotationException('Empty @ControllerId given');
+		}
+
+		$this->name = $value;
 	}
 
 	public function getName(): string

--- a/src/Annotation/Controller/ControllerPath.php
+++ b/src/Annotation/Controller/ControllerPath.php
@@ -20,19 +20,16 @@ final class ControllerPath
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @ControllerPath given');
-			}
-			$this->path = $values['value'];
-		} elseif (isset($values['path'])) {
-			if (empty($values['path'])) {
-				throw new AnnotationException('Empty @ControllerPath given');
-			}
-			$this->path = $values['path'];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @ControllerPath given');
 		}
+
+		$value = $values['value'];
+		if ($value === null || $value === '') {
+			throw new AnnotationException('Empty @ControllerPath given');
+		}
+
+		$this->path = $value;
 	}
 
 	public function getPath(): string

--- a/src/Annotation/Controller/GroupId.php
+++ b/src/Annotation/Controller/GroupId.php
@@ -20,19 +20,16 @@ final class GroupId
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @GroupId given');
-			}
-			$this->name = $values['value'];
-		} elseif (isset($values['name'])) {
-			if (empty($values['name'])) {
-				throw new AnnotationException('Empty @GroupId given');
-			}
-			$this->name = $values['name'];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @GroupId given');
 		}
+
+		$value = $values['value'];
+		if ($value === null || $value === '') {
+			throw new AnnotationException('Empty @GroupId given');
+		}
+
+		$this->name = $value;
 	}
 
 	public function getName(): string

--- a/src/Annotation/Controller/GroupPath.php
+++ b/src/Annotation/Controller/GroupPath.php
@@ -20,19 +20,16 @@ final class GroupPath
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @GroupPath given');
-			}
-			$this->path = $values['value'];
-		} elseif (isset($values['path'])) {
-			if (empty($values['path'])) {
-				throw new AnnotationException('Empty @GroupPath given');
-			}
-			$this->path = $values['path'];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @GroupPath given');
 		}
+
+		$value = $values['value'];
+		if ($value === null || $value === '') {
+			throw new AnnotationException('Empty @GroupPath given');
+		}
+
+		$this->path = $value;
 	}
 
 	public function getPath(): string

--- a/src/Annotation/Controller/Id.php
+++ b/src/Annotation/Controller/Id.php
@@ -20,19 +20,16 @@ final class Id
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @Id given');
-			}
-			$this->name = $values['value'];
-		} elseif (isset($values['name'])) {
-			if (empty($values['name'])) {
-				throw new AnnotationException('Empty @Id given');
-			}
-			$this->name = $values['name'];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @Id given');
 		}
+
+		$value = $values['value'];
+		if ($value === null || $value === '') {
+			throw new AnnotationException('Empty @Id given');
+		}
+
+		$this->name = $value;
 	}
 
 	public function getName(): string

--- a/src/Annotation/Controller/Method.php
+++ b/src/Annotation/Controller/Method.php
@@ -20,21 +20,21 @@ final class Method
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (is_array($values['value'])) {
-				$this->methods = $values['value'];
-			} elseif (is_string($values['value']) && !empty($values['value'])) {
-				$this->methods = [$values['value']];
-			} else {
-				throw new AnnotationException('Invalid @Method given');
-			}
-		} elseif (isset($values['methods']) && !empty($values['methods'])) {
-			$this->methods = $values['methods'];
-		} elseif (isset($values['method'])) {
-			$this->methods = [$values['method']];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @Method given');
 		}
+
+		$methods = $values['value'];
+		if ($methods === [] || $methods === null || $methods === '') {
+			throw new AnnotationException('Empty @Method given');
+		}
+
+		// Wrap single given method into array
+		if (!is_array($methods)) {
+			$methods = [$methods];
+		}
+
+		$this->methods = $methods;
 	}
 
 	/**

--- a/src/Annotation/Controller/Negotiations.php
+++ b/src/Annotation/Controller/Negotiations.php
@@ -20,14 +20,21 @@ final class Negotiations
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @Negotiations given');
-			}
-			$this->negotiations = is_array($values['value']) ? $values['value'] : [$values['value']];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @Negotiation given in @Negotiations');
 		}
+
+		$negotiations = $values['value'];
+		if ($negotiations === []) {
+			throw new AnnotationException('Empty @Negotiations given');
+		}
+
+		// Wrap single given request parameter into array
+		if (!is_array($negotiations)) {
+			$negotiations = [$negotiations];
+		}
+
+		$this->negotiations = $negotiations;
 	}
 
 	/**

--- a/src/Annotation/Controller/Path.php
+++ b/src/Annotation/Controller/Path.php
@@ -20,19 +20,16 @@ final class Path
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @Path given');
-			}
-			$this->path = $values['value'];
-		} elseif (isset($values['path'])) {
-			if (empty($values['path'])) {
-				throw new AnnotationException('Empty @Path given');
-			}
-			$this->path = $values['path'];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @Path given');
 		}
+
+		$value = $values['value'];
+		if ($value === null || $value === '') {
+			throw new AnnotationException('Empty @Path given');
+		}
+
+		$this->path = $value;
 	}
 
 	public function getPath(): string

--- a/src/Annotation/Controller/Request.php
+++ b/src/Annotation/Controller/Request.php
@@ -18,7 +18,7 @@ final class Request
 	private $entity;
 
 	/** @var bool */
-	private $required = false;
+	private $required;
 
 	/**
 	 * @param mixed[] $values
@@ -27,9 +27,7 @@ final class Request
 	{
 		$this->description = $values['description'] ?? null;
 		$this->entity = $values['entity'] ?? null;
-		if (isset($values['required']) && $values['required'] === true) {
-			$this->required = true;
-		}
+		$this->required = $values['required'] ?? false;
 	}
 
 	public function getEntity(): ?string

--- a/src/Annotation/Controller/RequestMapper.php
+++ b/src/Annotation/Controller/RequestMapper.php
@@ -23,11 +23,16 @@ final class RequestMapper
 	 */
 	public function __construct(array $values)
 	{
-		if (!isset($values['entity']) || empty($values['entity'])) {
+		if (!isset($values['entity'])) {
+			throw new AnnotationException('No @RequestMapper entity given');
+		}
+
+		$entity = $values['entity'];
+		if ($entity === null || $entity === '') {
 			throw new AnnotationException('Empty @RequestMapper entity given');
 		}
 
-		$this->entity = $values['entity'];
+		$this->entity = $entity;
 		$this->validation = $values['validation'] ?? true;
 	}
 

--- a/src/Annotation/Controller/RequestParameter.php
+++ b/src/Annotation/Controller/RequestParameter.php
@@ -39,16 +39,26 @@ final class RequestParameter
 	 */
 	public function __construct(array $values)
 	{
-		if (!isset($values['name']) || empty($values['name'])) {
+		if (!isset($values['name'])) {
+			throw new AnnotationException('No @RequestParameter name given');
+		}
+
+		$name = $values['name'];
+		if ($name === null || $name === '') {
 			throw new AnnotationException('Empty @RequestParameter name given');
 		}
 
-		if (!isset($values['type']) || empty($values['type'])) {
+		if (!isset($values['type'])) {
+			throw new AnnotationException('No @RequestParameter type given');
+		}
+
+		$type = $values['type'];
+		if ($type === null || $type === '') {
 			throw new AnnotationException('Empty @RequestParameter type given');
 		}
 
-		$this->name = $values['name'];
-		$this->type = $values['type'];
+		$this->name = $name;
+		$this->type = $type;
 		$this->required = $values['required'] ?? true;
 		$this->allowEmpty = $values['allowEmpty'] ?? false;
 		$this->deprecated = $values['deprecated'] ?? false;

--- a/src/Annotation/Controller/RequestParameters.php
+++ b/src/Annotation/Controller/RequestParameters.php
@@ -20,28 +20,35 @@ final class RequestParameters
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @RequestParameters given');
-			}
-			$this->parameters = is_array($values['value']) ? $values['value'] : [$values['value']];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @RequestParameter given in @RequestParameters');
 		}
 
+		$parameters = $values['value'];
+		if ($parameters === []) {
+			throw new AnnotationException('Empty @RequestParameters given');
+		}
+
+		// Wrap single given request parameter into array
+		if (!is_array($parameters)) {
+			$parameters = [$parameters];
+		}
+
 		$takenNames = [];
-		/** @var RequestParameter $value */
-		foreach ($values['value'] as $value) {
-			if (!isset($takenNames[$value->getIn()][$value->getName()])) {
-				$takenNames[$value->getIn()][$value->getName()] = $value;
+		/** @var RequestParameter $parameter */
+		foreach ($parameters as $parameter) {
+			if (!isset($takenNames[$parameter->getIn()][$parameter->getName()])) {
+				$takenNames[$parameter->getIn()][$parameter->getName()] = $parameter;
 			} else {
 				throw new AnnotationException(sprintf(
 					'Multiple @RequestParameter annotations with "name=%s" and "in=%s" given. Each parameter must have unique combination of location and name.',
-					$value->getName(),
-					$value->getIn()
+					$parameter->getName(),
+					$parameter->getIn()
 				));
 			}
 		}
+
+		$this->parameters = $parameters;
 	}
 
 	/**

--- a/src/Annotation/Controller/Response.php
+++ b/src/Annotation/Controller/Response.php
@@ -13,7 +13,7 @@ final class Response
 {
 
 	/** @var string */
-	private $code = 'default';
+	private $code;
 
 	/** @var string */
 	private $description;
@@ -26,12 +26,18 @@ final class Response
 	 */
 	public function __construct(array $values)
 	{
-		if (!isset($values['description']) || empty($values['description'])) {
+		if (!isset($values['description'])) {
+			throw new AnnotationException('No @Response description given');
+		}
+
+		$description = $values['description'];
+		if ($description === null || $description === '') {
 			throw new AnnotationException('Empty @Response description given');
 		}
+
 		$this->code = $values['code'] ?? 'default';
 		$this->entity = $values['entity'] ?? null;
-		$this->description = $values['description'];
+		$this->description = $description;
 	}
 
 	public function getDescription(): string

--- a/src/Annotation/Controller/ResponseMapper.php
+++ b/src/Annotation/Controller/ResponseMapper.php
@@ -20,11 +20,16 @@ final class ResponseMapper
 	 */
 	public function __construct(array $values)
 	{
-		if (!isset($values['entity']) || empty($values['entity'])) {
+		if (!isset($values['entity'])) {
+			throw new AnnotationException('No @ResponseMapper entity given');
+		}
+
+		$entity = $values['entity'];
+		if ($entity === null || $entity === '') {
 			throw new AnnotationException('Empty @ResponseMapper entity given');
 		}
 
-		$this->entity = $values['entity'];
+		$this->entity = $entity;
 	}
 
 	public function getEntity(): string

--- a/src/Annotation/Controller/Responses.php
+++ b/src/Annotation/Controller/Responses.php
@@ -20,27 +20,34 @@ final class Responses
 	 */
 	public function __construct(array $values)
 	{
-		if (isset($values['value'])) {
-			if (empty($values['value'])) {
-				throw new AnnotationException('Empty @Responses given');
-			}
-			$this->responses = is_array($values['value']) ? $values['value'] : [$values['value']];
-		} else {
+		if (!isset($values['value'])) {
 			throw new AnnotationException('No @Response given in @Responses');
 		}
 
+		$responses = $values['value'];
+		if ($responses === []) {
+			throw new AnnotationException('Empty @Responses given');
+		}
+
+		// Wrap single given response into array
+		if (!is_array($responses)) {
+			$responses = [$responses];
+		}
+
 		$takenCodes = [];
-		/** @var Response $value */
-		foreach ($values['value'] as $value) {
-			if (!isset($takenCodes[$value->getCode()])) {
-				$takenCodes[$value->getCode()] = $value;
+		/** @var Response $response */
+		foreach ($responses as $response) {
+			if (!isset($takenCodes[$response->getCode()])) {
+				$takenCodes[$response->getCode()] = $response;
 			} else {
 				throw new AnnotationException(sprintf(
 					'Multiple @Response annotations with "code=%s" given. Each response must have unique code.',
-					$value->getCode()
+					$response->getCode()
 				));
 			}
 		}
+
+		$this->responses = $responses;
 	}
 
 	/**

--- a/src/Annotation/Controller/Tag.php
+++ b/src/Annotation/Controller/Tag.php
@@ -27,11 +27,12 @@ final class Tag
 			throw new AnnotationException('No @Tag name given');
 		}
 
-		if (empty($values['name'])) {
+		$name = $values['name'];
+		if ($name === null || $name === '') {
 			throw new AnnotationException('Empty @Tag name given');
 		}
 
-		$this->name = $values['name'];
+		$this->name = $name;
 		$this->value = $values['value'] ?? null;
 	}
 

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -47,15 +47,21 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 		// Iterate over all controllers
 		foreach ($controllers as $def) {
+			$type = $def->getType();
+
+			if ($type === null) {
+				throw new InvalidStateException('Cannot analyse class with no type defined. Make sure all controllers have defined their class.');
+			}
+
 			// Analyse all parent classes
-			$class = $this->analyseClass($def->getType());
+			$class = $this->analyseClass($type);
 
 			// Check if a controller or his abstract has @Controller annotation,
 			// otherwise, skip this controller
 			if (!$this->acceptController($class)) continue;
 
 			// Create scheme endpoint
-			$schemeController = $builder->addController($def->getType());
+			$schemeController = $builder->addController($type);
 
 			// Parse @Controller, @ControllerPath, @ControllerId
 			$this->parseControllerClassAnnotations($schemeController, $class);

--- a/src/Decorator/DecoratorManager.php
+++ b/src/Decorator/DecoratorManager.php
@@ -2,6 +2,7 @@
 
 namespace Apitte\Core\Decorator;
 
+use Apitte\Core\Exception\Logical\InvalidStateException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -23,7 +24,7 @@ class DecoratorManager
 	/**
 	 * @param mixed[] $context
 	 */
-	public function decorateRequest(string $type, ServerRequestInterface $request, ResponseInterface $response, array $context = []): ?ServerRequestInterface
+	public function decorateRequest(string $type, ServerRequestInterface $request, ResponseInterface $response, array $context = []): ServerRequestInterface
 	{
 		$decorators = $this->decorators[$type] ?? [];
 
@@ -31,7 +32,9 @@ class DecoratorManager
 			/** @var ServerRequestInterface|null $request */
 			$request = $decorator->decorate($request, $response, $context);
 
-			if ($request === null) return null; // Cannot pass null to next decorator
+			if ($request === null) {
+				throw new InvalidStateException('Request decorator should always return.');
+			}
 		}
 
 		return $request;

--- a/tests/cases/Annotation/Controller/ControllerId.phpt
+++ b/tests/cases/Annotation/Controller/ControllerId.phpt
@@ -16,21 +16,10 @@ test(function (): void {
 		'value' => 'controller',
 	]);
 	Assert::same('controller', $controller->getName());
-
-	$controller = new ControllerId([
-		'name' => 'controller',
-	]);
-	Assert::same('controller', $controller->getName());
 });
 
 // Exception - no name
 test(function (): void {
-	Assert::exception(function (): void {
-		new ControllerId([
-			'name' => '',
-		]);
-	}, AnnotationException::class, 'Empty @ControllerId given');
-
 	Assert::exception(function (): void {
 		new ControllerId([
 			'value' => '',

--- a/tests/cases/Annotation/Controller/ControllerPath.phpt
+++ b/tests/cases/Annotation/Controller/ControllerPath.phpt
@@ -16,21 +16,10 @@ test(function (): void {
 		'value' => 'FakeControllerPath',
 	]);
 	Assert::same('FakeControllerPath', $path->getPath());
-
-	$path = new ControllerPath([
-		'path' => 'FakeControllerPath',
-	]);
-	Assert::equal('FakeControllerPath', $path->getPath());
 });
 
 // Exception - empty path
 test(function (): void {
-	Assert::exception(function (): void {
-		new ControllerPath([
-			'path' => '',
-		]);
-	}, AnnotationException::class, 'Empty @ControllerPath given');
-
 	Assert::exception(function (): void {
 		new ControllerPath([
 			'value' => '',

--- a/tests/cases/Annotation/Controller/GroupId.phpt
+++ b/tests/cases/Annotation/Controller/GroupId.phpt
@@ -16,21 +16,10 @@ test(function (): void {
 		'value' => 'group',
 	]);
 	Assert::same('group', $group->getName());
-
-	$group = new GroupId([
-		'name' => 'group',
-	]);
-	Assert::same('group', $group->getName());
 });
 
 // Exception - no name
 test(function (): void {
-	Assert::exception(function (): void {
-		new GroupId([
-			'name' => '',
-		]);
-	}, AnnotationException::class, 'Empty @GroupId given');
-
 	Assert::exception(function (): void {
 		new GroupId([
 			'value' => '',

--- a/tests/cases/Annotation/Controller/GroupPath.phpt
+++ b/tests/cases/Annotation/Controller/GroupPath.phpt
@@ -16,21 +16,10 @@ test(function (): void {
 		'value' => 'FakeGroupPath',
 	]);
 	Assert::same('FakeGroupPath', $path->getPath());
-
-	$path = new GroupPath([
-		'path' => 'FakeGroupPath',
-	]);
-	Assert::equal('FakeGroupPath', $path->getPath());
 });
 
 // Exception - empty path
 test(function (): void {
-	Assert::exception(function (): void {
-		new GroupPath([
-			'path' => '',
-		]);
-	}, AnnotationException::class, 'Empty @GroupPath given');
-
 	Assert::exception(function (): void {
 		new GroupPath([
 			'value' => '',

--- a/tests/cases/Annotation/Controller/Id.phpt
+++ b/tests/cases/Annotation/Controller/Id.phpt
@@ -16,21 +16,10 @@ test(function (): void {
 		'value' => 'id',
 	]);
 	Assert::same('id', $id->getName());
-
-	$id = new Id([
-		'name' => 'id',
-	]);
-	Assert::same('id', $id->getName());
 });
 
 // Exception - no name
 test(function (): void {
-	Assert::exception(function (): void {
-		new Id([
-			'name' => '',
-		]);
-	}, AnnotationException::class, 'Empty @Id given');
-
 	Assert::exception(function (): void {
 		new Id([
 			'value' => '',

--- a/tests/cases/Annotation/Controller/Method.phpt
+++ b/tests/cases/Annotation/Controller/Method.phpt
@@ -10,34 +10,26 @@ use Tester\Assert;
 
 require_once __DIR__ . '/../../../bootstrap.php';
 
-// Value
+// Ok
 test(function (): void {
 	$method = new Method(['value' => 'GET']);
 	Assert::equal(['GET'], $method->getMethods());
 
 	$method = new Method(['value' => ['GET', 'POST']]);
 	Assert::equal(['GET', 'POST'], $method->getMethods());
-
-	Assert::exception(function (): void {
-		new Method(['value' => 0]);
-	}, AnnotationException::class, 'Invalid @Method given');
 });
 
-// Methods
-test(function (): void {
-	$method = new Method(['methods' => ['GET', 'POST']]);
-	Assert::equal(['GET', 'POST'], $method->getMethods());
-});
-
-// Method
-test(function (): void {
-	$method = new Method(['method' => 'GET']);
-	Assert::equal(['GET'], $method->getMethods());
-});
-
-// Fails
+// Empty method
 test(function (): void {
 	Assert::exception(function (): void {
 		new Method([]);
 	}, AnnotationException::class, 'No @Method given');
+
+	Assert::exception(function (): void {
+		new Method(['value' => []]);
+	}, AnnotationException::class, 'Empty @Method given');
+
+	Assert::exception(function (): void {
+		new Method(['value' => '']);
+	}, AnnotationException::class, 'Empty @Method given');
 });

--- a/tests/cases/Annotation/Controller/Path.phpt
+++ b/tests/cases/Annotation/Controller/Path.phpt
@@ -16,21 +16,10 @@ test(function (): void {
 		'value' => 'FakePath',
 	]);
 	Assert::same('FakePath', $path->getPath());
-
-	$path = new Path([
-		'path' => 'FakePath',
-	]);
-	Assert::equal('FakePath', $path->getPath());
 });
 
 // Exception - empty path
 test(function (): void {
-	Assert::exception(function (): void {
-		new Path([
-			'path' => '',
-		]);
-	}, AnnotationException::class, 'Empty @Path given');
-
 	Assert::exception(function (): void {
 		new Path([
 			'value' => '',

--- a/tests/cases/Annotation/Controller/RequestMapper.phpt
+++ b/tests/cases/Annotation/Controller/RequestMapper.phpt
@@ -31,7 +31,7 @@ test(function (): void {
 test(function (): void {
 	Assert::exception(function (): void {
 		new RequestMapper([]);
-	}, AnnotationException::class, 'Empty @RequestMapper entity given');
+	}, AnnotationException::class, 'No @RequestMapper entity given');
 
 	Assert::exception(function (): void {
 		new RequestMapper([

--- a/tests/cases/Annotation/Controller/RequestParameter.phpt
+++ b/tests/cases/Annotation/Controller/RequestParameter.phpt
@@ -30,7 +30,7 @@ test(function (): void {
 test(function (): void {
 	Assert::exception(function (): void {
 		new RequestParameter([]);
-	}, AnnotationException::class, 'Empty @RequestParameter name given');
+	}, AnnotationException::class, 'No @RequestParameter name given');
 
 	Assert::exception(function (): void {
 		new RequestParameter([
@@ -39,13 +39,13 @@ test(function (): void {
 	}, AnnotationException::class, 'Empty @RequestParameter name given');
 });
 
-// Exception - no type nor description
+// Exception - no type
 test(function (): void {
 	Assert::exception(function (): void {
 		new RequestParameter([
 			'name' => 'Param',
 		]);
-	}, AnnotationException::class, 'Empty @RequestParameter type given');
+	}, AnnotationException::class, 'No @RequestParameter type given');
 
 	Assert::exception(function (): void {
 		new RequestParameter([

--- a/tests/cases/Annotation/Controller/ResponseMapper.phpt
+++ b/tests/cases/Annotation/Controller/ResponseMapper.phpt
@@ -23,7 +23,7 @@ test(function (): void {
 test(function (): void {
 	Assert::exception(function (): void {
 		new ResponseMapper([]);
-	}, AnnotationException::class, 'Empty @ResponseMapper entity given');
+	}, AnnotationException::class, 'No @ResponseMapper entity given');
 
 	Assert::exception(function (): void {
 		new ResponseMapper([

--- a/tests/cases/Decorator/DecoratorManager.phpt
+++ b/tests/cases/Decorator/DecoratorManager.phpt
@@ -28,19 +28,6 @@ test(function (): void {
 	Assert::same($request, $manager->decorateRequest(IDecorator::ON_HANDLER_BEFORE, $request, $response));
 });
 
-// Decorate request - return null
-test(function (): void {
-	$manager = new DecoratorManager();
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
-
-	$manager->addDecorator(IDecorator::ON_HANDLER_BEFORE, new ReturnRequestDecorator());
-	$manager->addDecorator(IDecorator::ON_HANDLER_BEFORE, new ReturnNullDecorator());
-	$manager->addDecorator(IDecorator::ON_HANDLER_BEFORE, new ReturnRequestDecorator());
-
-	Assert::same(null, $manager->decorateRequest(IDecorator::ON_HANDLER_BEFORE, $request, $response));
-});
-
 // Decorate request - no decorators
 test(function (): void {
 	$manager = new DecoratorManager();

--- a/tests/fixtures/Controllers/FoobarController.php
+++ b/tests/fixtures/Controllers/FoobarController.php
@@ -32,7 +32,7 @@ final class FoobarController extends ApiV1Controller
 
 	/**
 	 * @Path("/baz2")
-	 * @Method(methods={"PUT"})
+	 * @Method({"PUT"})
 	 */
 	public function baz3(ApiRequest $request, ApiResponse $response): void
 	{


### PR DESCRIPTION
Resolved most of phpstan real issues, fixed some potential bugs, droped alternative (undocumented) syntax for annotations and simplified annotations code.

Syntax `@Path(path="/foo")` is no longer valid. Annotation value is redundant, so `@Path("/foo")` should be enough. Also `@Path(value="/foo")` remains supported but it's doctrine/annotations built-in behavior, which cannot be easily changed.