### PR TITLE
Check instanceof ApiException fixed in SimpleErrorHandler

### DIFF
--- a/src/ErrorHandler/SimpleErrorHandler.php
+++ b/src/ErrorHandler/SimpleErrorHandler.php
@@ -51,7 +51,7 @@ class SimpleErrorHandler implements IErrorHandler
 		$data = [
 			'status' => 'error',
 			'code' => $code,
-			'message' => ($error instanceof ApiException && $error->getMessage() !== '') ? $error->getMessage() : 'Application encountered an internal error. Please try again later.',
+			'message' => $error instanceof ApiException ? $error->getMessage() : 'Application encountered an internal error. Please try again later.',
 		];
 
 		if ($error instanceof ApiException && $error->getContext() !== null) {

--- a/src/ErrorHandler/SimpleErrorHandler.php
+++ b/src/ErrorHandler/SimpleErrorHandler.php
@@ -51,7 +51,7 @@ class SimpleErrorHandler implements IErrorHandler
 		$data = [
 			'status' => 'error',
 			'code' => $code,
-			'message' => $error instanceof ApiResponse ? $error->getMessage() : 'Application encountered an internal error. Please try again later.',
+			'message' => ($error instanceof ApiException && $error->getMessage() !== '') ? $error->getMessage() : 'Application encountered an internal error. Please try again later.',
 		];
 
 		if ($error instanceof ApiException && $error->getContext() !== null) {

--- a/src/Exception/Api/ValidationException.php
+++ b/src/Exception/Api/ValidationException.php
@@ -11,7 +11,7 @@ class ValidationException extends ClientErrorException
 	/**
 	 * @param mixed[] $fields
 	 */
-	public function __construct(string $message = '', int $code = 422, ?Throwable $previous = null, array $fields = [])
+	public function __construct(string $message = 'Validation error. See details in the context.', int $code = 422, ?Throwable $previous = null, array $fields = [])
 	{
 		parent::__construct($message, $code, $previous, $fields);
 	}

--- a/src/Exception/Api/ValidationException.php
+++ b/src/Exception/Api/ValidationException.php
@@ -11,7 +11,7 @@ class ValidationException extends ClientErrorException
 	/**
 	 * @param mixed[] $fields
 	 */
-	public function __construct(string $message = 'Validation error. See details in the context.', int $code = 422, ?Throwable $previous = null, array $fields = [])
+	public function __construct(string $message = '', int $code = 422, ?Throwable $previous = null, array $fields = [])
 	{
 		parent::__construct($message, $code, $previous, $fields);
 	}


### PR DESCRIPTION
Hi,
  your commits from the last days are great :+1: 

I allowed to fix one bug in SimpleErrorHandler. Variable $error can never be of the type ApiResponse, but type of ApiException.

I also added default message to ValidationException. Original message "Application encountered an internal error. Please try again later." is not is not entirely ideal ;)

Best regards
Míra