### PR TITLE
Less strict request entities api

### DIFF
--- a/src/Mapping/RequestEntityMapping.php
+++ b/src/Mapping/RequestEntityMapping.php
@@ -42,7 +42,7 @@ class RequestEntityMapping
 		// Create entity
 		$entity = $this->createEntity($requestMapper, $request);
 
-		if ($entity) {
+		if ($entity !== null) {
 			$request = $request->withAttribute(RequestAttributes::ATTR_REQUEST_ENTITY, $entity);
 		}
 
@@ -51,15 +51,19 @@ class RequestEntityMapping
 
 	/**
 	 * @param ApiRequest $request
+	 * @return IRequestEntity|object|null
 	 */
-	protected function createEntity(EndpointRequestMapper $mapper, ServerRequestInterface $request): ?IRequestEntity
+	protected function createEntity(EndpointRequestMapper $mapper, ServerRequestInterface $request)
 	{
 		$entityClass = $mapper->getEntity();
 		$entity = new $entityClass();
 
 		// Allow modify entity in extended class
 		$entity = $this->modify($entity, $request);
-		if (!$entity) return null;
+
+		if ($entity === null) {
+			return null;
+		}
 
 		// Try to validate entity only if its enabled
 		if ($mapper->isValidation() === true) {
@@ -70,14 +74,24 @@ class RequestEntityMapping
 	}
 
 	/**
+	 * @param IRequestEntity|object $entity
 	 * @param ApiRequest $request
+	 * @return IRequestEntity|object|null
 	 */
-	protected function modify(IRequestEntity $entity, ServerRequestInterface $request): ?IRequestEntity
+	protected function modify($entity, ServerRequestInterface $request)
 	{
-		return $entity->fromRequest($request);
+		if ($entity instanceof IRequestEntity) {
+			return $entity->fromRequest($request);
+		}
+
+		return $entity;
 	}
 
-	protected function validate(IRequestEntity $entity): void
+	/**
+	 * @param object $entity
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 */
+	protected function validate($entity): void
 	{
 		if (!$this->validator) return;
 		$this->validator->validate($entity);

--- a/src/Schema/Validation/RequestMapperValidation.php
+++ b/src/Schema/Validation/RequestMapperValidation.php
@@ -3,7 +3,6 @@
 namespace Apitte\Core\Schema\Validation;
 
 use Apitte\Core\Exception\Logical\InvalidSchemaException;
-use Apitte\Core\Mapping\Request\IRequestEntity;
 use Apitte\Core\Schema\Builder\SchemaBuilder;
 
 class RequestMapperValidation implements IValidation
@@ -35,16 +34,6 @@ class RequestMapperValidation implements IValidation
 							$method->getName()
 						)
 					);
-				}
-
-				if (!isset(class_implements($mapper->getEntity())[IRequestEntity::class])) {
-					throw new InvalidSchemaException(sprintf(
-						'Request mapping entity "%s" in "%s::%s()" does not implement "%s"',
-						$mapper->getEntity(),
-						$controller->getClass(),
-						$method->getName(),
-						IRequestEntity::class
-					));
 				}
 			}
 		}

--- a/tests/cases/Schema/Validation/RequestMapperValidation.phpt
+++ b/tests/cases/Schema/Validation/RequestMapperValidation.phpt
@@ -7,12 +7,10 @@
 require_once __DIR__ . '/../../../bootstrap.php';
 
 use Apitte\Core\Exception\Logical\InvalidSchemaException;
-use Apitte\Core\Mapping\Request\IRequestEntity;
 use Apitte\Core\Schema\Builder\SchemaBuilder;
 use Apitte\Core\Schema\Validation\RequestMapperValidation;
 use Tester\Assert;
 use Tests\Fixtures\Mapping\Request\FooEntity;
-use Tests\Fixtures\Mapping\Request\InvalidEntity;
 
 // Validate: empty, no error
 test(function (): void {
@@ -53,28 +51,4 @@ test(function (): void {
 		$validator = new RequestMapperValidation();
 		$validator->validate($builder);
 	}, InvalidSchemaException::class, 'Request mapping entity "bar" in "c1::foo()" does not exist"');
-});
-
-// Validate: entity is invalid
-test(function (): void {
-	$builder = new SchemaBuilder();
-
-	$c1 = $builder->addController('c1');
-	$c1m1 = $c1->addMethod('foo');
-	$c1m1->setRequestMapper(InvalidEntity::class);
-
-	Assert::exception(
-		function () use ($builder): void {
-			$validator = new RequestMapperValidation();
-			$validator->validate($builder);
-		},
-		InvalidSchemaException::class,
-		sprintf(
-			'Request mapping entity "%s" in "%s::%s()" does not implement "%s"',
-			InvalidEntity::class,
-			'c1',
-			'foo',
-			IRequestEntity::class
-		)
-	);
 });


### PR DESCRIPTION
Let's make IRequestEntity optional until core itself have good enough implementation of entities

Related to #46 