### PR TITLE
Remove redundant dependencies from builder

### DIFF
--- a/src/DI/Loader/AbstractContainerLoader.php
+++ b/src/DI/Loader/AbstractContainerLoader.php
@@ -27,14 +27,4 @@ abstract class AbstractContainerLoader implements ILoader
 		return $this->builder->findByType(IController::class);
 	}
 
-	/**
-	 * @param ServiceDefinition[] $definitions
-	 */
-	protected function addDependencies(array $definitions): void
-	{
-		foreach ($definitions as $def) {
-			$this->builder->addDependency($def->getType());
-		}
-	}
-
 }

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -42,9 +42,6 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 		// Find all controllers by type (interface, annotation)
 		$controllers = $this->findControllers();
 
-		// Add controllers as dependencies to DIC
-		$this->addDependencies($controllers);
-
 		// Iterate over all controllers
 		foreach ($controllers as $def) {
 			$type = $def->getType();

--- a/tests/cases/DI/Loader/DoctrineAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineAnnotationLoader.phpt
@@ -18,7 +18,7 @@ use Tests\Fixtures\Controllers\InvalidGroupAnnotationController;
 use Tests\Fixtures\Controllers\InvalidGroupPathAnnotationController;
 use Tests\Fixtures\Controllers\PrefixedAnnotationController;
 
-// Check if controller is found and add as dependency to DIC
+// Check if controller is found
 test(function (): void {
 	$builder = Mockery::mock(ContainerBuilder::class);
 	$builder->shouldReceive('findByType')
@@ -31,10 +31,6 @@ test(function (): void {
 
 			return $controllers;
 		});
-
-	$builder->shouldReceive('addDependency')
-		->once()
-		->with(FoobarController::class);
 
 	$loader = new DoctrineAnnotationLoader($builder);
 	$schemaBuilder = $loader->load(new SchemaBuilder());


### PR DESCRIPTION
Should be save to remove that code because every service is also added as dependency internally by nette/di