### PR TITLE
IApplication interface

### DIFF
--- a/.docs/setup.md
+++ b/.docs/setup.md
@@ -22,14 +22,14 @@ Create entry point
 ```php
 // www/index.php
 
-use Apitte\Core\Application\Application;
+use Apitte\Core\Application\IApplication;
 use Nette\DI\Container;
 
 /** @var Container $container */
 $container = require __DIR__ . '/../app/bootstrap.php';
 
-/** @var Application $application */
-$application = $container->getByType(Application::class)->run();
+/** @var IApplication $application */
+$application = $container->getByType(IApplication::class)->run();
 ```
 
 ## Usage in combination with nette application
@@ -37,7 +37,7 @@ $application = $container->getByType(Application::class)->run();
 ```php
 // www/index.php
 
-use Apitte\Core\Application\Application as ApiApplication;
+use Apitte\Core\Application\IApplication as ApiApplication;
 use Nette\Application\Application as UIApplication;
 use Nette\DI\Container;
 

--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -5,6 +5,7 @@ namespace Apitte\Core\Application;
 use Apitte\Core\Dispatcher\IDispatcher;
 use Contributte\Psr7\Psr7Response;
 use Contributte\Psr7\Psr7ServerRequestFactory;
+use Psr\Http\Message\ServerRequestInterface;
 
 class Application implements IApplication
 {
@@ -20,6 +21,11 @@ class Application implements IApplication
 	public function run(): void
 	{
 		$request = Psr7ServerRequestFactory::fromGlobal();
+		$this->runWith($request);
+	}
+
+	public function runWith(ServerRequestInterface $request): void
+	{
 		$response = new Psr7Response();
 
 		$response = $this->dispatcher->dispatch($request, $response);

--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -6,7 +6,7 @@ use Apitte\Core\Dispatcher\IDispatcher;
 use Contributte\Psr7\Psr7Response;
 use Contributte\Psr7\Psr7ServerRequestFactory;
 
-class Application
+class Application implements IApplication
 {
 
 	/** @var IDispatcher */

--- a/src/Application/IApplication.php
+++ b/src/Application/IApplication.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace Apitte\Core\Application;
+
+interface IApplication
+{
+
+	public function run(): void;
+
+}

--- a/src/Application/IApplication.php
+++ b/src/Application/IApplication.php
@@ -2,9 +2,13 @@
 
 namespace Apitte\Core\Application;
 
+use Psr\Http\Message\ServerRequestInterface;
+
 interface IApplication
 {
 
 	public function run(): void;
+
+	public function runWith(ServerRequestInterface $request): void;
 
 }

--- a/src/DI/Plugin/CoreServicesPlugin.php
+++ b/src/DI/Plugin/CoreServicesPlugin.php
@@ -3,6 +3,7 @@
 namespace Apitte\Core\DI\Plugin;
 
 use Apitte\Core\Application\Application;
+use Apitte\Core\Application\IApplication;
 use Apitte\Core\Dispatcher\JsonDispatcher;
 use Apitte\Core\Dispatcher\WrappedDispatcher;
 use Apitte\Core\ErrorHandler\IErrorHandler;
@@ -41,7 +42,7 @@ class CoreServicesPlugin extends AbstractPlugin
 
 		$builder->addDefinition($this->prefix('application'))
 			->setFactory(Application::class, [$dispatcher])
-			->setType(Application::class);
+			->setType(IApplication::class);
 
 		// Catch exception only in debug mode if explicitly enabled
 		$catchException = !$globalConfig['debug'] || $globalConfig['catchException'];


### PR DESCRIPTION
With this change will be possible:
- implement `MiddlewareApplication` in apitte/middlewares
- move `ErrorHandler` into `Application` so errors from middlewares could be handled as well
- use `Application` inside apitte/presenter - presenter and middlewares will be finally fully compatible