### PR TITLE
Enforce ApiRequest and ApiResponse

### DIFF
--- a/.docs/decorators.md
+++ b/.docs/decorators.md
@@ -58,8 +58,8 @@ namespace App\Api\Decorator;
 
 use Apitte\Core\Decorator\IRequestDecorator;
 use Apitte\Core\Exception\Runtime\EarlyReturnResponseException;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class RequestMetadataDecorator implements IRequestDecorator
 {
@@ -67,7 +67,7 @@ class RequestMetadataDecorator implements IRequestDecorator
     /**
      * @throws EarlyReturnResponseException If other request decorators and also deeper layers (endpoint) should be skipped
      */
-    public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+    public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
     {
         // Do something with request (e.g. add useful attributes for endpoint)
         $request = $request->withAttribute('attributeName', 'attributeValue');
@@ -92,8 +92,8 @@ namespace App\Api\Decorator;
 
 use Apitte\Core\Decorator\IRequestDecorator;
 use Apitte\Core\Exception\Runtime\EarlyReturnResponseException;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use function GuzzleHttp\Psr7\stream_for;
 
 class RequestAuthenticationDecorator implements IRequestDecorator
@@ -102,7 +102,7 @@ class RequestAuthenticationDecorator implements IRequestDecorator
     /**
      * @throws EarlyReturnResponseException If other request decorators and also deeper layers (endpoint) should be skipped
      */
-    public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+    public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
     {
         if ($userAuthenticationFailed) {
             $body = stream_for(json_encode([
@@ -158,8 +158,8 @@ namespace App\Api\Decorator;
 
 use Apitte\Core\Decorator\IResponseDecorator;
 use Apitte\Core\Exception\Runtime\EarlyReturnResponseException;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class ExampleResponseDecorator implements IResponseDecorator
 {
@@ -167,7 +167,7 @@ class ExampleResponseDecorator implements IResponseDecorator
     /**
      * @throws EarlyReturnResponseException If other response decorators should be skipped
      */
-    public function decorateResponse(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    public function decorateResponse(ApiRequest $request, ApiResponse $response): ApiResponse
     {
         // Do something with response (e.g. transform data)
         return $response;
@@ -193,14 +193,15 @@ See [apitte/negotiation](https://github.com/apitte/negotiation) for details.
 ```php
 namespace App\Api\Decorator;
 
-use Apitte\Core\Decorator\IErrorDecorator;use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Decorator\IErrorDecorator;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Throwable;
 
 class ExampleExceptionDecorator implements IErrorDecorator
 {
     
-    public function decorateError(ServerRequestInterface $request, ResponseInterface $response, Throwable $error): ResponseInterface
+    public function decorateError(ApiRequest $request, ApiResponse $response, Throwable $error): ApiResponse
     {
         $response = $this->errorToResponse($response, $error);
         return $response;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,9 +26,6 @@ parameters:
 		- '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\(Apitte\\Core\\UI\\Controller\\IController, string\) given\.$#'
 		- '#^Call to function is_subclass_of\(\) with Apitte\\Core\\Mapping\\Parameter\\ITypeMapper\|string (.*)#'
 
-		# Maybe later - complicated to fix
-		- '#^.*should be contravariant with parameter.*$#'
-
 		# Missing strict comparison
 		- '#^Only booleans are allowed in#'
 

--- a/src/Adjuster/FileResponseAdjuster.php
+++ b/src/Adjuster/FileResponseAdjuster.php
@@ -2,19 +2,19 @@
 
 namespace Apitte\Core\Adjuster;
 
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Http\ApiResponse;
 use Psr\Http\Message\StreamInterface;
 
 class FileResponseAdjuster
 {
 
 	public static function adjust(
-		ResponseInterface $response,
+		ApiResponse $response,
 		StreamInterface $stream,
 		string $filename,
 		string $contentType = 'application/octet-stream',
 		bool $forceDownload = true
-	): ResponseInterface
+	): ApiResponse
 	{
 		return $response
 			->withHeader('Content-Type', $contentType)

--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -3,9 +3,10 @@
 namespace Apitte\Core\Application;
 
 use Apitte\Core\Dispatcher\IDispatcher;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Contributte\Psr7\Psr7Response;
 use Contributte\Psr7\Psr7ServerRequestFactory;
-use Psr\Http\Message\ServerRequestInterface;
 
 class Application implements IApplication
 {
@@ -20,13 +21,13 @@ class Application implements IApplication
 
 	public function run(): void
 	{
-		$request = Psr7ServerRequestFactory::fromGlobal();
+		$request = new ApiRequest(Psr7ServerRequestFactory::fromGlobal());
 		$this->runWith($request);
 	}
 
-	public function runWith(ServerRequestInterface $request): void
+	public function runWith(ApiRequest $request): void
 	{
-		$response = new Psr7Response();
+		$response = new ApiResponse(new Psr7Response());
 
 		$response = $this->dispatcher->dispatch($request, $response);
 

--- a/src/Application/IApplication.php
+++ b/src/Application/IApplication.php
@@ -2,13 +2,13 @@
 
 namespace Apitte\Core\Application;
 
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
 
 interface IApplication
 {
 
 	public function run(): void;
 
-	public function runWith(ServerRequestInterface $request): void;
+	public function runWith(ApiRequest $request): void;
 
 }

--- a/src/Decorator/DecoratorManager.php
+++ b/src/Decorator/DecoratorManager.php
@@ -2,8 +2,8 @@
 
 namespace Apitte\Core\Decorator;
 
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Throwable;
 
 class DecoratorManager
@@ -27,7 +27,7 @@ class DecoratorManager
 		return $this;
 	}
 
-	public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+	public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
 	{
 		foreach ($this->requestDecorators as $decorator) {
 			$request = $decorator->decorateRequest($request, $response);
@@ -45,7 +45,7 @@ class DecoratorManager
 		return $this;
 	}
 
-	public function decorateResponse(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function decorateResponse(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		foreach ($this->responseDecorators as $decorator) {
 			$response = $decorator->decorateResponse($request, $response);
@@ -63,7 +63,7 @@ class DecoratorManager
 		return $this;
 	}
 
-	public function decorateError(ServerRequestInterface $request, ResponseInterface $response, Throwable $error): ?ResponseInterface
+	public function decorateError(ApiRequest $request, ApiResponse $response, Throwable $error): ?ApiResponse
 	{
 		// If there is no exception handler defined so return null (and exception will be thrown in DecoratedDispatcher)
 		if ($this->errorDecorators === []) {

--- a/src/Decorator/IErrorDecorator.php
+++ b/src/Decorator/IErrorDecorator.php
@@ -4,18 +4,11 @@ namespace Apitte\Core\Decorator;
 
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 interface IErrorDecorator
 {
 
-	/**
-	 * @param ApiRequest|ServerRequestInterface $request
-	 * @param ApiResponse|ResponseInterface     $response
-	 * @return ApiResponse|ResponseInterface    $response
-	 */
-	public function decorateError(ServerRequestInterface $request, ResponseInterface $response, Throwable $error): ResponseInterface;
+	public function decorateError(ApiRequest $request, ApiResponse $response, Throwable $error): ApiResponse;
 
 }

--- a/src/Decorator/IRequestDecorator.php
+++ b/src/Decorator/IRequestDecorator.php
@@ -5,18 +5,13 @@ namespace Apitte\Core\Decorator;
 use Apitte\Core\Exception\Runtime\EarlyReturnResponseException;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 interface IRequestDecorator
 {
 
 	/**
-	 * @param ApiRequest|ServerRequestInterface $request
-	 * @param ApiResponse|ResponseInterface $response
-	 * @return ApiRequest|ServerRequestInterface
 	 * @throws EarlyReturnResponseException If other request decorators and also deeper layers (endpoint) should be skipped
 	 */
-	public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface;
+	public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest;
 
 }

--- a/src/Decorator/IResponseDecorator.php
+++ b/src/Decorator/IResponseDecorator.php
@@ -5,18 +5,13 @@ namespace Apitte\Core\Decorator;
 use Apitte\Core\Exception\Runtime\EarlyReturnResponseException;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 interface IResponseDecorator
 {
 
 	/**
-	 * @param ApiRequest|ServerRequestInterface $request
-	 * @param ApiResponse|ResponseInterface     $response
-	 * @return ApiResponse|ResponseInterface $response
 	 * @throws EarlyReturnResponseException If other response decorators should be skipped
 	 */
-	public function decorateResponse(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface;
+	public function decorateResponse(ApiRequest $request, ApiResponse $response): ApiResponse;
 
 }

--- a/src/Decorator/RequestEntityDecorator.php
+++ b/src/Decorator/RequestEntityDecorator.php
@@ -3,9 +3,8 @@
 namespace Apitte\Core\Decorator;
 
 use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Mapping\RequestEntityMapping;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 class RequestEntityDecorator implements IRequestDecorator
 {
@@ -18,10 +17,7 @@ class RequestEntityDecorator implements IRequestDecorator
 		$this->mapping = $mapping;
 	}
 
-	/**
-	 * @param ApiRequest $request
-	 */
-	public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+	public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
 	{
 		return $this->mapping->map($request, $response);
 	}

--- a/src/Decorator/RequestParametersDecorator.php
+++ b/src/Decorator/RequestParametersDecorator.php
@@ -2,9 +2,9 @@
 
 namespace Apitte\Core\Decorator;
 
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Mapping\RequestParameterMapping;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 class RequestParametersDecorator implements IRequestDecorator
 {
@@ -17,7 +17,7 @@ class RequestParametersDecorator implements IRequestDecorator
 		$this->mapping = $mapping;
 	}
 
-	public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+	public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
 	{
 		return $this->mapping->map($request, $response);
 	}

--- a/src/Dispatcher/DecoratedDispatcher.php
+++ b/src/Dispatcher/DecoratedDispatcher.php
@@ -17,7 +17,6 @@ use Apitte\Negotiation\Http\ArrayEntity;
 use Apitte\Negotiation\Http\MappingEntity;
 use Apitte\Negotiation\Http\ScalarEntity;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 class DecoratedDispatcher extends CoreDispatcher
@@ -32,12 +31,7 @@ class DecoratedDispatcher extends CoreDispatcher
 		$this->decoratorManager = $decoratorManager;
 	}
 
-	/**
-	 * @param ApiRequest|ServerRequestInterface $request
-	 * @param ApiResponse|ResponseInterface $response
-	 * @return ApiResponse|ResponseInterface $response
-	 */
-	public function dispatch(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function dispatch(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		try {
 			// Route and call handler
@@ -66,12 +60,7 @@ class DecoratedDispatcher extends CoreDispatcher
 		return $response;
 	}
 
-	/**
-	 * @param ApiRequest $request
-	 * @param ApiResponse $response
-	 * @return ApiResponse|ResponseInterface $response
-	 */
-	protected function handle(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	protected function handle(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		// Pass endpoint to response
 		$endpoint = $request->getAttribute(RequestAttributes::ATTR_ENDPOINT, null);
@@ -108,6 +97,10 @@ class DecoratedDispatcher extends CoreDispatcher
 				throw new InvalidStateException(sprintf('Endpoint returned response must implement "%s"', ResponseInterface::class));
 			}
 
+			if (!($result instanceof ApiResponse)) { //TODO - deprecation warning
+				$result = new ApiResponse($result);
+			}
+
 			$response = $result;
 		}
 
@@ -122,14 +115,13 @@ class DecoratedDispatcher extends CoreDispatcher
 
 	/**
 	 * @param mixed $result
-	 * @param ApiResponse $response
 	 */
-	protected function negotiate($result, ResponseInterface $response): ApiResponse
+	protected function negotiate($result, ApiResponse $response): ApiResponse
 	{
 		if (!class_exists(AbstractEntity::class)) {
 			throw new InvalidStateException(sprintf(
 				'If you want return anything else than "%s" from your api endpoint then install "apitte/negotiation".',
-				ResponseInterface::class
+				ApiResponse::class
 			));
 		}
 

--- a/src/Dispatcher/IDispatcher.php
+++ b/src/Dispatcher/IDispatcher.php
@@ -2,12 +2,12 @@
 
 namespace Apitte\Core\Dispatcher;
 
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 interface IDispatcher
 {
 
-	public function dispatch(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface;
+	public function dispatch(ApiRequest $request, ApiResponse $response): ApiResponse;
 
 }

--- a/src/Dispatcher/JsonDispatcher.php
+++ b/src/Dispatcher/JsonDispatcher.php
@@ -3,14 +3,15 @@
 namespace Apitte\Core\Dispatcher;
 
 use Apitte\Core\Exception\Logical\InvalidStateException;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Nette\Utils\Json;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 class JsonDispatcher extends CoreDispatcher
 {
 
-	protected function handle(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	protected function handle(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		$result = $this->handler->handle($request, $response);
 
@@ -29,10 +30,14 @@ class JsonDispatcher extends CoreDispatcher
 			throw new InvalidStateException(sprintf('Endpoint returned response must implement "%s"', ResponseInterface::class));
 		}
 
+		if (!($response instanceof ApiResponse)) { //TODO - deprecation warning
+			$response = new ApiResponse($response);
+		}
+
 		return $response;
 	}
 
-	public function fallback(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function fallback(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		$response = $response->withStatus(404)
 			->withHeader('Content-Type', 'application/json');

--- a/src/Dispatcher/WrappedDispatcher.php
+++ b/src/Dispatcher/WrappedDispatcher.php
@@ -5,8 +5,6 @@ namespace Apitte\Core\Dispatcher;
 use Apitte\Core\ErrorHandler\IErrorHandler;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 class WrappedDispatcher implements IDispatcher
@@ -24,41 +22,14 @@ class WrappedDispatcher implements IDispatcher
 		$this->errorHandler = $errorHandler;
 	}
 
-	public function dispatch(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function dispatch(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
-		// Create API/HTTP objects
-		$request = $this->createApiRequest($request);
-		$response = $this->createApiResponse($response);
-
 		try {
 			// Dispatch our classes
 			$response = $this->inner->dispatch($request, $response);
 		} catch (Throwable $exception) {
 			// Process exception so it could be logged and transformed into response
 			$response = $this->errorHandler->handle($exception);
-		}
-
-		// Unwrap response
-		$response = $this->unwrap($response);
-
-		return $response;
-	}
-
-	protected function createApiRequest(ServerRequestInterface $request): ApiRequest
-	{
-		return new ApiRequest($request);
-	}
-
-	protected function createApiResponse(ResponseInterface $response): ApiResponse
-	{
-		return new ApiResponse($response);
-	}
-
-	protected function unwrap(ResponseInterface $response): ResponseInterface
-	{
-		if ($response instanceof ApiResponse) {
-			// Get original response
-			return $response->getOriginalResponse();
 		}
 
 		return $response;

--- a/src/ErrorHandler/IErrorHandler.php
+++ b/src/ErrorHandler/IErrorHandler.php
@@ -2,7 +2,7 @@
 
 namespace Apitte\Core\ErrorHandler;
 
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Http\ApiResponse;
 use Throwable;
 
 interface IErrorHandler
@@ -11,6 +11,6 @@ interface IErrorHandler
 	/**
 	 * Log error and generate response
 	 */
-	public function handle(Throwable $error): ResponseInterface;
+	public function handle(Throwable $error): ApiResponse;
 
 }

--- a/src/ErrorHandler/PsrLogErrorHandler.php
+++ b/src/ErrorHandler/PsrLogErrorHandler.php
@@ -3,7 +3,7 @@
 namespace Apitte\Core\ErrorHandler;
 
 use Apitte\Core\Exception\ApiException;
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Http\ApiResponse;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -18,7 +18,7 @@ class PsrLogErrorHandler extends SimpleErrorHandler
 		$this->logger = $logger;
 	}
 
-	public function handle(Throwable $error): ResponseInterface
+	public function handle(Throwable $error): ApiResponse
 	{
 		// Log exception only if it's not designed to be displayed
 		if (!($error instanceof ApiException)) {

--- a/src/ErrorHandler/SimpleErrorHandler.php
+++ b/src/ErrorHandler/SimpleErrorHandler.php
@@ -6,7 +6,6 @@ use Apitte\Core\Exception\ApiException;
 use Apitte\Core\Exception\Runtime\SnapshotException;
 use Apitte\Core\Http\ApiResponse;
 use GuzzleHttp\Psr7\Response;
-use Psr\Http\Message\ResponseInterface;
 use Throwable;
 use function GuzzleHttp\Psr7\stream_for;
 
@@ -21,7 +20,7 @@ class SimpleErrorHandler implements IErrorHandler
 		$this->catchException = $catchException;
 	}
 
-	public function handle(Throwable $error): ResponseInterface
+	public function handle(Throwable $error): ApiResponse
 	{
 		// Rethrow error if it should not be catch (debug only)
 		if (!$this->catchException) {
@@ -43,7 +42,7 @@ class SimpleErrorHandler implements IErrorHandler
 		return $this->createResponseFromError($error);
 	}
 
-	protected function createResponseFromError(Throwable $error): ResponseInterface
+	protected function createResponseFromError(Throwable $error): ApiResponse
 	{
 		$code = $error->getCode();
 		$code = $code < 400 || $code > 600 ? 500 : $code;

--- a/src/Exception/Runtime/EarlyReturnResponseException.php
+++ b/src/Exception/Runtime/EarlyReturnResponseException.php
@@ -3,21 +3,21 @@
 namespace Apitte\Core\Exception\Runtime;
 
 use Apitte\Core\Exception\RuntimeException;
-use Psr\Http\Message\ResponseInterface;
+use Apitte\Core\Http\ApiResponse;
 
 class EarlyReturnResponseException extends RuntimeException
 {
 
-	/** @var ResponseInterface */
+	/** @var ApiResponse */
 	protected $response;
 
-	public function __construct(ResponseInterface $response)
+	public function __construct(ApiResponse $response)
 	{
 		parent::__construct();
 		$this->response = $response;
 	}
 
-	public function getResponse(): ResponseInterface
+	public function getResponse(): ApiResponse
 	{
 		return $this->response;
 	}

--- a/src/Exception/Runtime/SnapshotException.php
+++ b/src/Exception/Runtime/SnapshotException.php
@@ -3,8 +3,8 @@
 namespace Apitte\Core\Exception\Runtime;
 
 use Apitte\Core\Exception\RuntimeException;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Throwable;
 
 /**
@@ -13,25 +13,25 @@ use Throwable;
 class SnapshotException extends RuntimeException
 {
 
-	/** @var ServerRequestInterface */
+	/** @var ApiRequest */
 	protected $request;
 
-	/** @var ResponseInterface */
+	/** @var ApiResponse */
 	protected $response;
 
-	public function __construct(Throwable $exception, ServerRequestInterface $request, ResponseInterface $response)
+	public function __construct(Throwable $exception, ApiRequest $request, ApiResponse $response)
 	{
 		parent::__construct($exception->getMessage(), $exception->getCode(), $exception);
 		$this->request = $request;
 		$this->response = $response;
 	}
 
-	public function getRequest(): ServerRequestInterface
+	public function getRequest(): ApiRequest
 	{
 		return $this->request;
 	}
 
-	public function getResponse(): ResponseInterface
+	public function getResponse(): ApiResponse
 	{
 		return $this->response;
 	}

--- a/src/Handler/IHandler.php
+++ b/src/Handler/IHandler.php
@@ -2,8 +2,8 @@
 
 namespace Apitte\Core\Handler;
 
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 interface IHandler
 {
@@ -11,6 +11,6 @@ interface IHandler
 	/**
 	 * @return mixed
 	 */
-	public function handle(ServerRequestInterface $request, ResponseInterface $response);
+	public function handle(ApiRequest $request, ApiResponse $response);
 
 }

--- a/src/Handler/ServiceHandler.php
+++ b/src/Handler/ServiceHandler.php
@@ -4,12 +4,12 @@ namespace Apitte\Core\Handler;
 
 use Apitte\Core\Exception\Logical\InvalidArgumentException;
 use Apitte\Core\Exception\Logical\InvalidStateException;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Schema\Endpoint;
 use Apitte\Core\UI\Controller\IController;
 use Nette\DI\Container;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 class ServiceHandler implements IHandler
 {
@@ -25,7 +25,7 @@ class ServiceHandler implements IHandler
 	/**
 	 * @return mixed
 	 */
-	public function handle(ServerRequestInterface $request, ResponseInterface $response)
+	public function handle(ApiRequest $request, ApiResponse $response)
 	{
 		// Create and trigger callback
 		$endpoint = $this->getEndpoint($request);
@@ -44,7 +44,7 @@ class ServiceHandler implements IHandler
 		return new ServiceCallback($service, $method);
 	}
 
-	protected function getEndpoint(ServerRequestInterface $request): Endpoint
+	protected function getEndpoint(ApiRequest $request): Endpoint
 	{
 		/** @var Endpoint|null $endpoint */
 		$endpoint = $request->getAttribute(RequestAttributes::ATTR_ENDPOINT);

--- a/src/Mapping/RequestEntityMapping.php
+++ b/src/Mapping/RequestEntityMapping.php
@@ -4,13 +4,12 @@ namespace Apitte\Core\Mapping;
 
 use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Mapping\Request\IRequestEntity;
 use Apitte\Core\Mapping\Validator\IEntityValidator;
 use Apitte\Core\Schema\Endpoint;
 use Apitte\Core\Schema\EndpointRequestMapper;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 class RequestEntityMapping
 {
@@ -23,10 +22,7 @@ class RequestEntityMapping
 		$this->validator = $validator;
 	}
 
-	/**
-	 * @param ApiRequest $request
-	 */
-	public function map(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+	public function map(ApiRequest $request, ApiResponse $response): ApiRequest
 	{
 		/** @var Endpoint|null $endpoint */
 		$endpoint = $request->getAttribute(RequestAttributes::ATTR_ENDPOINT);
@@ -50,10 +46,9 @@ class RequestEntityMapping
 	}
 
 	/**
-	 * @param ApiRequest $request
 	 * @return IRequestEntity|object|null
 	 */
-	protected function createEntity(EndpointRequestMapper $mapper, ServerRequestInterface $request)
+	protected function createEntity(EndpointRequestMapper $mapper, ApiRequest $request)
 	{
 		$entityClass = $mapper->getEntity();
 		$entity = new $entityClass();
@@ -75,10 +70,9 @@ class RequestEntityMapping
 
 	/**
 	 * @param IRequestEntity|object $entity
-	 * @param ApiRequest $request
 	 * @return IRequestEntity|object|null
 	 */
-	protected function modify($entity, ServerRequestInterface $request)
+	protected function modify($entity, ApiRequest $request)
 	{
 		if ($entity instanceof IRequestEntity) {
 			return $entity->fromRequest($request);

--- a/src/Mapping/RequestParameterMapping.php
+++ b/src/Mapping/RequestParameterMapping.php
@@ -7,12 +7,11 @@ use Apitte\Core\Exception\Logical\InvalidArgumentException;
 use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Core\Exception\Runtime\InvalidArgumentTypeException;
 use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Mapping\Parameter\ITypeMapper;
 use Apitte\Core\Schema\Endpoint;
 use Apitte\Core\Schema\EndpointParameter;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 class RequestParameterMapping
 {
@@ -40,10 +39,7 @@ class RequestParameterMapping
 		$this->types[$type] = $mapper;
 	}
 
-	/**
-	 * @param ServerRequestInterface|ApiRequest $request
-	 */
-	public function map(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+	public function map(ApiRequest $request, ApiResponse $response): ApiRequest
 	{
 		/** @var Endpoint|null $endpoint */
 		$endpoint = $request->getAttribute(RequestAttributes::ATTR_ENDPOINT);

--- a/src/Router/IRouter.php
+++ b/src/Router/IRouter.php
@@ -2,11 +2,11 @@
 
 namespace Apitte\Core\Router;
 
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
 
 interface IRouter
 {
 
-	public function match(ServerRequestInterface $request): ?ServerRequestInterface;
+	public function match(ApiRequest $request): ?ApiRequest;
 
 }

--- a/src/Router/SimpleRouter.php
+++ b/src/Router/SimpleRouter.php
@@ -3,12 +3,12 @@
 namespace Apitte\Core\Router;
 
 use Apitte\Core\Exception\Api\ClientErrorException;
+use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Schema\Endpoint;
 use Apitte\Core\Schema\EndpointParameter;
 use Apitte\Core\Schema\Schema;
 use Apitte\Core\Utils\Regex;
-use Psr\Http\Message\ServerRequestInterface;
 
 class SimpleRouter implements IRouter
 {
@@ -21,7 +21,7 @@ class SimpleRouter implements IRouter
 		$this->schema = $schema;
 	}
 
-	public function match(ServerRequestInterface $request): ?ServerRequestInterface
+	public function match(ApiRequest $request): ?ApiRequest
 	{
 		$endpoints = $this->schema->getEndpoints();
 
@@ -54,7 +54,7 @@ class SimpleRouter implements IRouter
 		return null;
 	}
 
-	protected function matchEndpoint(Endpoint $endpoint, ServerRequestInterface $request): ?ServerRequestInterface
+	protected function matchEndpoint(Endpoint $endpoint, ApiRequest $request): ?ApiRequest
 	{
 		// Try match given URL (path) by build pattern
 		$request = $this->compareUrl($endpoint, $request);
@@ -67,7 +67,7 @@ class SimpleRouter implements IRouter
 		return $request;
 	}
 
-	protected function compareUrl(Endpoint $endpoint, ServerRequestInterface $request): ?ServerRequestInterface
+	protected function compareUrl(Endpoint $endpoint, ApiRequest $request): ?ApiRequest
 	{
 		// Parse url from request
 		$url = $request->getUri()->getPath();

--- a/tests/cases/Adjuster/FileResponseAdjuster.phpt
+++ b/tests/cases/Adjuster/FileResponseAdjuster.phpt
@@ -7,11 +7,12 @@
 require_once __DIR__ . '/../../bootstrap.php';
 
 use Apitte\Core\Adjuster\FileResponseAdjuster;
+use Apitte\Core\Http\ApiResponse;
 use Contributte\Psr7\Psr7ResponseFactory;
 use Tester\Assert;
 
 test(function (): void {
-	$response = Psr7ResponseFactory::fromGlobal();
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$response = FileResponseAdjuster::adjust($response, $response->getBody(), 'filename');
 
 	Assert::same(

--- a/tests/cases/Decorator/DecoratorManager.phpt
+++ b/tests/cases/Decorator/DecoratorManager.phpt
@@ -7,6 +7,8 @@
 require_once __DIR__ . '/../../bootstrap.php';
 
 use Apitte\Core\Decorator\DecoratorManager;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Contributte\Psr7\Psr7ResponseFactory;
 use Contributte\Psr7\Psr7ServerRequestFactory;
 use Tester\Assert;
@@ -16,8 +18,8 @@ use Tests\Fixtures\Decorator\ReturnResponseDecorator;
 // Decorate request
 test(function (): void {
 	$manager = new DecoratorManager();
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$manager->addRequestDecorator(new ReturnRequestDecorator());
 	$manager->addRequestDecorator(new ReturnRequestDecorator());
@@ -28,8 +30,8 @@ test(function (): void {
 // Decorate request - no decorators
 test(function (): void {
 	$manager = new DecoratorManager();
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	Assert::same($request, $manager->decorateRequest($request, $response));
 });
@@ -37,8 +39,8 @@ test(function (): void {
 // Decorate response
 test(function (): void {
 	$manager = new DecoratorManager();
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$manager->addResponseDecorator(new ReturnResponseDecorator());
 	$manager->addResponseDecorator(new ReturnResponseDecorator());
@@ -49,8 +51,8 @@ test(function (): void {
 // Decorate response - no decorators
 test(function (): void {
 	$manager = new DecoratorManager();
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	Assert::same($response, $manager->decorateResponse($request, $response));
 });
@@ -58,8 +60,8 @@ test(function (): void {
 // Decorate error
 test(function (): void {
 	$manager = new DecoratorManager();
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$error = new Exception('I am a generic exception');
 
 	$manager->addErrorDecorator(new ReturnResponseDecorator());
@@ -71,8 +73,8 @@ test(function (): void {
 // Decorate error - no decorators
 test(function (): void {
 	$manager = new DecoratorManager();
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$error = new Exception('I am a generic exception');
 
 	Assert::same(null, $manager->decorateError($request, $response, $error));

--- a/tests/cases/Dispatcher/CoreDispatcher.phpt
+++ b/tests/cases/Dispatcher/CoreDispatcher.phpt
@@ -9,6 +9,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 use Apitte\Core\Dispatcher\CoreDispatcher;
 use Apitte\Core\Exception\Api\ClientErrorException;
 use Apitte\Core\Exception\Logical\InvalidStateException;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Contributte\Psr7\Psr7ResponseFactory;
 use Contributte\Psr7\Psr7ServerRequestFactory;
 use Psr\Http\Message\ResponseInterface;
@@ -19,8 +21,8 @@ use Tests\Fixtures\Router\FakeRouter;
 
 // Request matched, use handler, return response
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new CoreDispatcher(new FakeRouter(true), new FakeResponseHandler());
 	Assert::same($response, $dispatcher->dispatch($request, $response));
@@ -28,8 +30,8 @@ test(function (): void {
 
 // Request matched, use invalid handler, throw exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new CoreDispatcher(new FakeRouter(true), new FakeNullHandler());
 
@@ -40,8 +42,8 @@ test(function (): void {
 
 // Request not matched, throw exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new CoreDispatcher(new FakeRouter(false), new FakeResponseHandler());
 

--- a/tests/cases/Dispatcher/DecoratedDispatcher.phpt
+++ b/tests/cases/Dispatcher/DecoratedDispatcher.phpt
@@ -10,6 +10,7 @@ use Apitte\Core\Decorator\DecoratorManager;
 use Apitte\Core\Dispatcher\DecoratedDispatcher;
 use Apitte\Core\Exception\Api\ClientErrorException;
 use Apitte\Core\Exception\Logical\InvalidStateException;
+use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Schema\Endpoint;
@@ -33,8 +34,8 @@ use Tests\Fixtures\Router\FakeRouter;
 
 // Match request, use handler and be happy, everything is ok!
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new DecoratedDispatcher(new FakeRouter(true), new FakeResponseHandler(), new DecoratorManager());
 	Assert::same($response, $dispatcher->dispatch($request, $response));
@@ -42,7 +43,7 @@ test(function (): void {
 
 // Match request, add endpoint, use handler and be happy, everything is ok!
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
 	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$handler = new EndpointHandler('class', 'method');
@@ -56,8 +57,8 @@ test(function (): void {
 
 // Match request, use invalid handler, throw exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new DecoratedDispatcher(new FakeRouter(true), new FakeNullHandler(), new DecoratorManager());
 
@@ -68,20 +69,20 @@ test(function (): void {
 
 // Match request, use invalid handler, throw exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new DecoratedDispatcher(new FakeRouter(true), new ReturnFooBarHandler(), new DecoratorManager());
 
 	Assert::exception(function () use ($dispatcher, $request, $response): void {
 		$dispatcher->dispatch($request, $response);
-	}, InvalidStateException::class, sprintf('If you want return anything else than "%s" from your api endpoint then install "apitte/negotiation".', ResponseInterface::class));
+	}, InvalidStateException::class, sprintf('If you want return anything else than "%s" from your api endpoint then install "apitte/negotiation".', ApiResponse::class));
 });
 
 // Match request, decorate request, throw exception, return response from exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$manager = new DecoratorManager();
 	$manager->addRequestDecorator(new EarlyReturnResponseExceptionDecorator());
@@ -93,8 +94,8 @@ test(function (): void {
 
 // Match request, use handler, decorate response, throw exception, return response from exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$manager = new DecoratorManager();
 	$manager->addResponseDecorator(new EarlyReturnResponseExceptionDecorator());
@@ -106,8 +107,8 @@ test(function (): void {
 
 // Match request, use handler, throw and catch exception, decorate response with exception in context and then (for tests) throw exception again
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$manager = new DecoratorManager();
 	$manager->addErrorDecorator(new RethrowErrorDecorator());
@@ -121,8 +122,8 @@ test(function (): void {
 
 // Match request, use handler, throw and catch exception then trow it again because DecoratorManager doesn't have any decorators so returned null
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new DecoratedDispatcher(new FakeRouter(true), new ErroneousHandler(), new DecoratorManager());
 	Assert::exception(function () use ($dispatcher, $request, $response): void {
@@ -132,8 +133,8 @@ test(function (): void {
 
 // No match, throw exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new DecoratedDispatcher(new FakeRouter(false), new FakeResponseHandler(), new DecoratorManager());
 

--- a/tests/cases/Dispatcher/JsonDispatcher.phpt
+++ b/tests/cases/Dispatcher/JsonDispatcher.phpt
@@ -8,6 +8,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 
 use Apitte\Core\Dispatcher\JsonDispatcher;
 use Apitte\Core\Exception\Logical\InvalidStateException;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Contributte\Psr7\Psr7ResponseFactory;
 use Contributte\Psr7\Psr7ServerRequestFactory;
 use Nette\Utils\Json;
@@ -20,8 +22,8 @@ use Tests\Fixtures\Router\FakeRouter;
 
 // Matched, use handle
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new JsonDispatcher(new FakeRouter(true), new FakeResponseHandler());
 	Assert::same($response, $dispatcher->dispatch($request, $response));
@@ -29,8 +31,8 @@ test(function (): void {
 
 // Matched, use handle, write to response body result from handle
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new JsonDispatcher(new FakeRouter(true), new ReturnFooBarHandler());
 	$response = $dispatcher->dispatch($request, $response);
@@ -41,8 +43,8 @@ test(function (): void {
 
 // Matched, use invalid handle, throw exception
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new JsonDispatcher(new FakeRouter(true), new FakeNullHandler());
 	Assert::exception(function () use ($dispatcher, $request, $response): void {
@@ -52,8 +54,8 @@ test(function (): void {
 
 // Not matched, use fallback, write error to response body
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new JsonDispatcher(new FakeRouter(false), new FakeResponseHandler());
 	$response = $dispatcher->dispatch($request, $response);

--- a/tests/cases/Dispatcher/WrappedDispatcher.phpt
+++ b/tests/cases/Dispatcher/WrappedDispatcher.phpt
@@ -8,14 +8,16 @@ require_once __DIR__ . '/../../bootstrap.php';
 
 use Apitte\Core\Dispatcher\WrappedDispatcher;
 use Apitte\Core\ErrorHandler\SimpleErrorHandler;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Contributte\Psr7\Psr7ResponseFactory;
 use Contributte\Psr7\Psr7ServerRequestFactory;
 use Tester\Assert;
 use Tests\Fixtures\Dispatcher\FakeDispatcher;
 
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$dispatcher = new WrappedDispatcher(new FakeDispatcher(), new SimpleErrorHandler());
 

--- a/tests/cases/Handler/ServiceHandler.phpt
+++ b/tests/cases/Handler/ServiceHandler.phpt
@@ -6,6 +6,8 @@
 
 use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Core\Handler\ServiceHandler;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Schema\Endpoint;
 use Apitte\Core\Schema\EndpointHandler;
@@ -25,8 +27,8 @@ test(function (): void {
 	$sh = new ServiceHandler($container);
 
 	Assert::exception(function () use ($sh): void {
-		$request = Psr7ServerRequestFactory::fromSuperGlobal();
-		$response = Psr7ResponseFactory::fromGlobal();
+		$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+		$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 		$sh->handle($request, $response);
 	}, InvalidStateException::class, 'Attribute "apitte.core.endpoint" is required');
@@ -60,7 +62,8 @@ test(function (): void {
 
 	$request = Psr7ServerRequestFactory::fromSuperGlobal()
 		->withAttribute(RequestAttributes::ATTR_ENDPOINT, $endpoint);
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest($request);
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 
 	$res = $sh->handle($request, $response);
 

--- a/tests/cases/Mapping/RequestEntityMapping.phpt
+++ b/tests/cases/Mapping/RequestEntityMapping.phpt
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../../bootstrap.php';
 
 use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Mapping\RequestEntityMapping;
 use Apitte\Core\Schema\Endpoint;
@@ -21,7 +22,7 @@ use Tests\Fixtures\Mapping\Request\FooEntity;
 // Add entity to request
 test(function (): void {
 	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
-	$response = Psr7ResponseFactory::fromGlobal();
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$mapping = new RequestEntityMapping();
 
 	$handler = new EndpointHandler('class', 'method');
@@ -40,7 +41,7 @@ test(function (): void {
 // Don't modify request by entity - method foo is not supported
 test(function (): void {
 	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
-	$response = Psr7ResponseFactory::fromGlobal();
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$mapping = new RequestEntityMapping();
 
 	$handler = new EndpointHandler('class', 'method');
@@ -56,8 +57,8 @@ test(function (): void {
 
 // No request mapper, return request
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$mapping = new RequestEntityMapping();
 
 	$handler = new EndpointHandler('class', 'method');
@@ -68,8 +69,8 @@ test(function (): void {
 
 // Exception - missing attribute
 test(function (): void {
-	$request = Psr7ServerRequestFactory::fromSuperGlobal();
-	$response = Psr7ResponseFactory::fromGlobal();
+	$request = new ApiRequest(Psr7ServerRequestFactory::fromSuperGlobal());
+	$response = new ApiResponse(Psr7ResponseFactory::fromGlobal());
 	$mapping = new RequestEntityMapping();
 
 	Assert::exception(function () use ($mapping, $request, $response): void {

--- a/tests/cases/Router/SimpleRouter.phpt
+++ b/tests/cases/Router/SimpleRouter.phpt
@@ -7,6 +7,7 @@
 require_once __DIR__ . '/../../bootstrap.php';
 
 use Apitte\Core\Exception\Api\ClientErrorException;
+use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\RequestAttributes;
 use Apitte\Core\Router\SimpleRouter;
 use Apitte\Core\Schema\Endpoint;
@@ -31,6 +32,7 @@ test(function (): void {
 	$schema->addEndpoint($endpoint);
 
 	$request = Psr7ServerRequestFactory::fromSuperGlobal()->withNewUri('http://example.com/users/22/');
+	$request = new ApiRequest($request);
 	$request2 = $request->withNewUri('http://example.com/not-matched/');
 	$router = new SimpleRouter($schema);
 	$matched = $router->match($request);
@@ -60,6 +62,7 @@ test(function (): void {
 	$schema->addEndpoint($endpoint);
 
 	$request = Psr7ServerRequestFactory::fromSuperGlobal()->withNewUri('http://example.com/users/1/baz');
+	$request = new ApiRequest($request);
 	$router = new SimpleRouter($schema);
 	$matched = $router->match($request);
 
@@ -88,6 +91,7 @@ test(function (): void {
 
 	$request = Psr7ServerRequestFactory::fromSuperGlobal()->withNewUri('http://example.com/foo')
 		->withMethod('POST');
+	$request = new ApiRequest($request);
 	$router = new SimpleRouter($schema);
 	$matched = $router->match($request);
 
@@ -108,6 +112,7 @@ test(function (): void {
 
 	$request = Psr7ServerRequestFactory::fromSuperGlobal()->withNewUri('http://example.com/foo')
 		->withMethod('POST');
+	$request = new ApiRequest($request);
 	$router = new SimpleRouter($schema);
 
 	Assert::exception(function () use ($router, $request): void {
@@ -128,6 +133,7 @@ test(function (): void {
 
 	$request = Psr7ServerRequestFactory::fromSuperGlobal()
 		->withMethod('GET');
+	$request = new ApiRequest($request);
 	$router = new SimpleRouter($schema);
 	$matched = $router->match($request);
 

--- a/tests/fixtures/Decorator/EarlyReturnResponseExceptionDecorator.php
+++ b/tests/fixtures/Decorator/EarlyReturnResponseExceptionDecorator.php
@@ -5,18 +5,18 @@ namespace Tests\Fixtures\Decorator;
 use Apitte\Core\Decorator\IRequestDecorator;
 use Apitte\Core\Decorator\IResponseDecorator;
 use Apitte\Core\Exception\Runtime\EarlyReturnResponseException;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class EarlyReturnResponseExceptionDecorator implements IRequestDecorator, IResponseDecorator
 {
 
-	public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+	public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
 	{
 		throw new EarlyReturnResponseException($response);
 	}
 
-	public function decorateResponse(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function decorateResponse(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		throw new EarlyReturnResponseException($response);
 	}

--- a/tests/fixtures/Decorator/RethrowErrorDecorator.php
+++ b/tests/fixtures/Decorator/RethrowErrorDecorator.php
@@ -3,14 +3,14 @@
 namespace Tests\Fixtures\Decorator;
 
 use Apitte\Core\Decorator\IErrorDecorator;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Throwable;
 
 class RethrowErrorDecorator implements IErrorDecorator
 {
 
-	public function decorateError(ServerRequestInterface $request, ResponseInterface $response, Throwable $error): ResponseInterface
+	public function decorateError(ApiRequest $request, ApiResponse $response, Throwable $error): ApiResponse
 	{
 		throw $error;
 	}

--- a/tests/fixtures/Decorator/ReturnRequestDecorator.php
+++ b/tests/fixtures/Decorator/ReturnRequestDecorator.php
@@ -3,13 +3,13 @@
 namespace Tests\Fixtures\Decorator;
 
 use Apitte\Core\Decorator\IRequestDecorator;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class ReturnRequestDecorator implements IRequestDecorator
 {
 
-	public function decorateRequest(ServerRequestInterface $request, ResponseInterface $response): ServerRequestInterface
+	public function decorateRequest(ApiRequest $request, ApiResponse $response): ApiRequest
 	{
 		return $request;
 	}

--- a/tests/fixtures/Decorator/ReturnResponseDecorator.php
+++ b/tests/fixtures/Decorator/ReturnResponseDecorator.php
@@ -4,19 +4,19 @@ namespace Tests\Fixtures\Decorator;
 
 use Apitte\Core\Decorator\IErrorDecorator;
 use Apitte\Core\Decorator\IResponseDecorator;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use Throwable;
 
 class ReturnResponseDecorator implements IResponseDecorator, IErrorDecorator
 {
 
-	public function decorateResponse(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function decorateResponse(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		return $response;
 	}
 
-	public function decorateError(ServerRequestInterface $request, ResponseInterface $response, Throwable $error): ResponseInterface
+	public function decorateError(ApiRequest $request, ApiResponse $response, Throwable $error): ApiResponse
 	{
 		return $response;
 	}

--- a/tests/fixtures/Dispatcher/FakeDispatcher.php
+++ b/tests/fixtures/Dispatcher/FakeDispatcher.php
@@ -3,13 +3,13 @@
 namespace Tests\Fixtures\Dispatcher;
 
 use Apitte\Core\Dispatcher\IDispatcher;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class FakeDispatcher implements IDispatcher
 {
 
-	public function dispatch(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function dispatch(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		return $response;
 	}

--- a/tests/fixtures/Handler/ErroneousHandler.php
+++ b/tests/fixtures/Handler/ErroneousHandler.php
@@ -3,14 +3,14 @@
 namespace Tests\Fixtures\Handler;
 
 use Apitte\Core\Handler\IHandler;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 use RuntimeException;
 
 class ErroneousHandler implements IHandler
 {
 
-	public function handle(ServerRequestInterface $request, ResponseInterface $response): void
+	public function handle(ApiRequest $request, ApiResponse $response): void
 	{
 		throw new RuntimeException(sprintf('I am %s!', self::class));
 	}

--- a/tests/fixtures/Handler/FakeNullHandler.php
+++ b/tests/fixtures/Handler/FakeNullHandler.php
@@ -3,8 +3,8 @@
 namespace Tests\Fixtures\Handler;
 
 use Apitte\Core\Handler\IHandler;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class FakeNullHandler implements IHandler
 {
@@ -12,7 +12,7 @@ class FakeNullHandler implements IHandler
 	/**
 	 * @return null
 	 */
-	public function handle(ServerRequestInterface $request, ResponseInterface $response)
+	public function handle(ApiRequest $request, ApiResponse $response)
 	{
 		return null;
 	}

--- a/tests/fixtures/Handler/FakeResponseHandler.php
+++ b/tests/fixtures/Handler/FakeResponseHandler.php
@@ -3,13 +3,13 @@
 namespace Tests\Fixtures\Handler;
 
 use Apitte\Core\Handler\IHandler;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class FakeResponseHandler implements IHandler
 {
 
-	public function handle(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+	public function handle(ApiRequest $request, ApiResponse $response): ApiResponse
 	{
 		return $response;
 	}

--- a/tests/fixtures/Handler/ReturnFooBarHandler.php
+++ b/tests/fixtures/Handler/ReturnFooBarHandler.php
@@ -3,8 +3,8 @@
 namespace Tests\Fixtures\Handler;
 
 use Apitte\Core\Handler\IHandler;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
+use Apitte\Core\Http\ApiRequest;
+use Apitte\Core\Http\ApiResponse;
 
 class ReturnFooBarHandler implements IHandler
 {
@@ -12,7 +12,7 @@ class ReturnFooBarHandler implements IHandler
 	/**
 	 * @return mixed[]
 	 */
-	public function handle(ServerRequestInterface $request, ResponseInterface $response): array
+	public function handle(ApiRequest $request, ApiResponse $response): array
 	{
 		return ['foo', 'bar'];
 	}

--- a/tests/fixtures/Router/FakeRouter.php
+++ b/tests/fixtures/Router/FakeRouter.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Fixtures\Router;
 
+use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Router\IRouter;
-use Psr\Http\Message\ServerRequestInterface;
 
 class FakeRouter implements IRouter
 {
@@ -16,7 +16,7 @@ class FakeRouter implements IRouter
 		$this->match = $match;
 	}
 
-	public function match(ServerRequestInterface $request): ?ServerRequestInterface
+	public function match(ApiRequest $request): ?ApiRequest
 	{
 		if ($this->match) {
 			return $request;


### PR DESCRIPTION
Resolves contravariance of method signatures - many methods already required ApiRequest and ApiResponse but had requirement only in annotations so I enforced them everywhere.

Endpoints could still return ResponseInterface.