### PR TITLE
Fix bug in Application.php, multiple settings of content-type header

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -42,7 +42,13 @@ class Application implements IApplication
 
 		foreach ($response->getHeaders() as $name => $values) {
 			foreach ($values as $value) {
-				header(sprintf('%s: %s', $name, $value), false);
+				// never send multiple content-type headers
+				if (preg_match('/content-type/i', $name)) {
+					header(sprintf('%s: %s', $name, $value));
+				}
+				else {
+					header(sprintf('%s: %s', $name, $value), false);
+				}
 			}
 		}
 


### PR DESCRIPTION
Some 3rd parties libraries, can set content-type at the beginning of script.

Like Nette

https://github.com/nette/http/blob/master/src/Bridges/HttpDI/HttpExtension.php#L38

Content-Type cant be set multiple times, therefore the replace parameter should be true.

In other case the browser will crash during the finishing request.