### PR TITLE
routes order

### DIFF
--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -229,7 +229,7 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 				// Parse @Method ===========================
 				if (get_class($annotation) === Method::class) {
 					/** @var Method $annotation */
-					$schemaMethod->addMethods($annotation->getMethods());
+					$schemaMethod->addHttpMethods($annotation->getMethods());
 					continue;
 				}
 

--- a/src/DI/Loader/NeonLoader.php
+++ b/src/DI/Loader/NeonLoader.php
@@ -47,7 +47,7 @@ class NeonLoader implements ILoader
 			$method->setId($settings['id'] ?? null);
 			$method->setPath($settings['path'] ?? '');
 			$method->setDescription($settings['description'] ?? '');
-			$method->addMethods($settings['methods'] ?? []);
+			$method->addHttpMethods($settings['methods'] ?? []);
 			$method->addTags($settings['tags'] ?? []);
 			$method->setOpenApi($settings['openapi'] ?? []);
 			$this->setMethodParameters($method, $settings['parameters'] ?? []);

--- a/src/Schema/Builder/Controller/Method.php
+++ b/src/Schema/Builder/Controller/Method.php
@@ -20,7 +20,7 @@ final class Method
 	private $description;
 
 	/** @var string[] */
-	private $methods = [];
+	private $httpMethods = [];
 
 	/** @var mixed[] */
 	private $tags = [];
@@ -89,31 +89,31 @@ final class Method
 	/**
 	 * @return string[]
 	 */
-	public function getMethods(): array
+	public function getHttpMethods(): array
 	{
-		return $this->methods;
+		return $this->httpMethods;
 	}
 
 	/**
-	 * @param string[] $methods
+	 * @param string[] $httpMethods
 	 */
-	public function setMethods(array $methods): void
+	public function setHttpMethods(array $httpMethods): void
 	{
-		$this->methods = $methods;
+		$this->httpMethods = $httpMethods;
 	}
 
-	public function addMethod(string $method): void
+	public function addHttpMethod(string $method): void
 	{
-		$this->methods[] = strtoupper($method);
+		$this->httpMethods[] = strtoupper($method);
 	}
 
 	/**
-	 * @param string[] $methods
+	 * @param string[] $httpMethods
 	 */
-	public function addMethods(array $methods): void
+	public function addHttpMethods(array $httpMethods): void
 	{
-		foreach ($methods as $method) {
-			$this->addMethod($method);
+		foreach ($httpMethods as $httpMethod) {
+			$this->addHttpMethod($httpMethod);
 		}
 	}
 

--- a/src/Schema/Hierarchy/ControllerMethodPair.php
+++ b/src/Schema/Hierarchy/ControllerMethodPair.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Apitte\Core\Schema\Hierarchy;
+
+use Apitte\Core\Schema\Builder\Controller\Controller;
+use Apitte\Core\Schema\Builder\Controller\Method;
+
+class ControllerMethodPair
+{
+
+	/** @var Controller */
+	private $controller;
+
+	/** @var Method */
+	private $method;
+
+	public function __construct(Controller $controller, Method $method)
+	{
+		$this->controller = $controller;
+		$this->method = $method;
+	}
+
+	public function getController(): Controller
+	{
+		return $this->controller;
+	}
+
+	public function getMethod(): Method
+	{
+		return $this->method;
+	}
+
+}

--- a/src/Schema/Hierarchy/HierarchicalNode.php
+++ b/src/Schema/Hierarchy/HierarchicalNode.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types = 1);
+
+namespace Apitte\Core\Schema\Hierarchy;
+
+use Nette\Utils\Strings;
+
+class HierarchicalNode
+{
+
+	/** @var string */
+	private $path;
+
+	/** @var HierarchicalNode[] */
+	private $nodes = [];
+
+	/** @var ControllerMethodPair[] */
+	private $endpoints = [];
+
+	public function __construct(string $path)
+	{
+		$this->path = $path;
+	}
+
+	public function getPath(): string
+	{
+		return $this->path;
+	}
+
+	public function addNode(string $path): HierarchicalNode
+	{
+		if (!isset($this->nodes[$path])) {
+			$this->nodes[$path] = new HierarchicalNode($path);
+		}
+
+		return $this->nodes[$path];
+	}
+
+	public function addEndpoint(ControllerMethodPair $endpoint): void
+	{
+		// Store endpoint under index with GET, POST, PATCH format
+		$httpMethods = $endpoint->getMethod()->getHttpMethods();
+		sort($httpMethods);
+		$index = implode(', ', $httpMethods);
+
+		$this->endpoints[$index] = $endpoint;
+	}
+
+	/**
+	 * @return ControllerMethodPair[]
+	 */
+	public function getSortedEndpoints(): array
+	{
+		// Return endpoints sorted by HTTP method
+		ksort($this->endpoints);
+
+		return array_values($this->endpoints);
+	}
+
+	/**
+	 * @return HierarchicalNode[]
+	 */
+	public function getSortedNodes(): array
+	{
+		$staticNodes = [];
+		$variableNodes = [];
+		$rootNode = null;
+
+		// Divide static and variable nodes
+		foreach ($this->nodes as $key => $node) {
+			$path = $node->getPath();
+			if (Strings::contains($path, '{') && Strings::contains($path, '}')) {
+				$variableNodes[] = $node;
+			} else {
+				$staticNodes[] = $node;
+			}
+		}
+
+		// Sort static nodes from A to Z and keep empty path last
+		uasort($staticNodes, static function (HierarchicalNode $a, HierarchicalNode $b) {
+			$pathA = $a->getPath();
+			$pathB = $b->getPath();
+
+			// Same path, don't flip
+			if ($pathA === $pathB) {
+				return 0;
+			}
+
+			// Path is empty, keep it last
+			if ($pathA === '') {
+				return 1;
+			}
+
+			// Path is empty, keep it last
+			if ($pathB === '') {
+				return -1;
+			}
+
+			return (strcmp($pathA, $pathB) <= -1) ? -1 : 1;
+		});
+
+		return array_merge($staticNodes, $variableNodes);
+	}
+
+}

--- a/src/Schema/Hierarchy/HierarchyBuilder.php
+++ b/src/Schema/Hierarchy/HierarchyBuilder.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types = 1);
+
+namespace Apitte\Core\Schema\Hierarchy;
+
+use Apitte\Core\Schema\Builder\Controller\Controller;
+
+class HierarchyBuilder
+{
+
+	/** @var Controller[] */
+	private $controllers;
+
+	/** @var HierarchicalNode[] */
+	private $nodes = [];
+
+	/**
+	 * @param Controller[] $controllers
+	 */
+	public function __construct(array $controllers)
+	{
+		$this->controllers = $controllers;
+	}
+
+	/**
+	 * Hierarchical node is representation of one path part without / (e.g. users/{id} is considered to be two nodes)
+	 */
+	private function addNode(string $path): HierarchicalNode
+	{
+		if (!isset($this->nodes[$path])) {
+			$this->nodes[$path] = new HierarchicalNode($path);
+		}
+
+		return $this->nodes[$path];
+	}
+
+	public function getHierarchy(): HierarchicalNode
+	{
+		$rootNode = $this->addNode('');
+
+		foreach ($this->controllers as $controller) {
+			$controllerPaths = $controller->getGroupPaths();
+			$controllerPaths[] = $controller->getPath();
+			$controllerPathParts = $this->splitPathParts($controllerPaths);
+
+			foreach ($controller->getMethods() as $method) {
+				$methodPathParts = $this->splitPathParts($method->getPath());
+				$allPathParts = array_merge($controllerPathParts, $methodPathParts);
+				if ($allPathParts === []) {
+					// Full path to endpoint is just /, it's a root node
+					$rootNode->addEndpoint(new ControllerMethodPair($controller, $method));
+				} else {
+					$lastPathPartKey = array_keys($allPathParts)[count($allPathParts) - 1]; // array_key_last for php < 7.3.0
+
+					$previousNode = $rootNode;
+					foreach ($allPathParts as $key => $part) {
+						$node = $previousNode->addNode($part);
+
+						if ($key === $lastPathPartKey) {
+							$node->addEndpoint(new ControllerMethodPair($controller, $method));
+						}
+
+						$previousNode = $node;
+					}
+				}
+			}
+		}
+
+		return $rootNode;
+	}
+
+	/**
+	 * Creates ['api', 'v1', 'users', '{id}'] from /api/v1/users/{id}
+	 *
+	 * @param string|string[] $paths
+	 * @return string[]
+	 */
+	protected function splitPathParts($paths): array
+	{
+		$parts = [];
+
+		if (is_array($paths)) {
+			foreach ($paths as $path) {
+				$parts = array_merge($parts, $this->splitPathParts($path));
+			}
+		} else {
+			$parts = array_merge($parts, explode('/', $paths));
+		}
+
+		// Remove empty indexes created during split
+		$parts = array_filter($parts, static function ($value) {
+			return $value !== null && $value !== '';
+		});
+
+		return $parts;
+	}
+
+	/**
+	 * @return ControllerMethodPair[]
+	 */
+	private function getSortedEndpointsFromNode(HierarchicalNode $node): array
+	{
+		$endpoints = [];
+
+		foreach ($node->getSortedNodes() as $subnode) {
+			$endpoints = array_merge($endpoints, $this->getSortedEndpointsFromNode($subnode));
+		}
+
+		$endpoints = array_merge($endpoints, $node->getSortedEndpoints());
+
+		return $endpoints;
+	}
+
+	/**
+	 * @return ControllerMethodPair[]
+	 */
+	public function getSortedEndpoints(): array
+	{
+		return $this->getSortedEndpointsFromNode($this->getHierarchy());
+	}
+
+}

--- a/src/Schema/Serialization/ArraySerializator.php
+++ b/src/Schema/Serialization/ArraySerializator.php
@@ -93,7 +93,7 @@ final class ArraySerializator implements ISerializator
 			],
 			'id' => $id,
 			'tags' => array_merge($controller->getTags(), $method->getTags()),
-			'methods' => $method->getMethods(),
+			'methods' => $method->getHttpMethods(),
 			'mask' => $mask,
 			'description' => $method->getDescription(),
 			'parameters' => [],

--- a/src/Schema/Serialization/ArraySerializator.php
+++ b/src/Schema/Serialization/ArraySerializator.php
@@ -8,6 +8,7 @@ use Apitte\Core\Schema\Builder\Controller\Method;
 use Apitte\Core\Schema\Builder\Controller\MethodParameter;
 use Apitte\Core\Schema\Builder\SchemaBuilder;
 use Apitte\Core\Schema\EndpointParameter;
+use Apitte\Core\Schema\Hierarchy\HierarchyBuilder;
 use Apitte\Core\Utils\Helpers;
 use Apitte\Core\Utils\Regex;
 
@@ -19,21 +20,21 @@ final class ArraySerializator implements ISerializator
 	 */
 	public function serialize(SchemaBuilder $builder): array
 	{
-		$controllers = $builder->getControllers();
+		$hierarchyBuilder = new HierarchyBuilder($builder->getControllers());
+		$endpoints = $hierarchyBuilder->getSortedEndpoints();
 		$schema = [];
 
-		// Iterate over all controllers
-		foreach ($controllers as $controller) {
+		foreach ($endpoints as $endpoint) {
+			$controller = $endpoint->getController();
+			$method = $endpoint->getMethod();
 
-			// Iterate over all controller api methods
-			foreach ($controller->getMethods() as $method) {
-
-				// Skip invalid methods
-				if ($method->getPath() === '') continue;
-
-				$endpoint = $this->serializeEndpoint($controller, $method);
-				$schema[] = $endpoint;
+			// Skip invalid methods
+			if ($method->getPath() === '') {
+				continue;
 			}
+
+			$endpoint = $this->serializeEndpoint($controller, $method);
+			$schema[] = $endpoint;
 		}
 
 		return $schema;

--- a/src/Schema/Validation/FullpathValidation.php
+++ b/src/Schema/Validation/FullpathValidation.php
@@ -31,7 +31,7 @@ class FullpathValidation implements IValidation
 
 		foreach ($controllers as $controller) {
 			foreach ($controller->getMethods() as $method) {
-				foreach ($method->getMethods() as $httpMethod) {
+				foreach ($method->getHttpMethods() as $httpMethod) {
 
 					$maskp = array_merge(
 						$controller->getGroupPaths(),

--- a/tests/cases/DI/Loader/DoctrineAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineAnnotationLoader.phpt
@@ -61,11 +61,11 @@ test(function (): void {
 
 	Assert::equal('baz1', $controller->getMethods()['baz1']->getName());
 	Assert::equal('/baz1', $controller->getMethods()['baz1']->getPath());
-	Assert::equal(['GET'], $controller->getMethods()['baz1']->getMethods());
+	Assert::equal(['GET'], $controller->getMethods()['baz1']->getHttpMethods());
 
 	Assert::equal('baz2', $controller->getMethods()['baz2']->getName());
 	Assert::equal('/baz2', $controller->getMethods()['baz2']->getPath());
-	Assert::equal(['GET', 'POST'], $controller->getMethods()['baz2']->getMethods());
+	Assert::equal(['GET', 'POST'], $controller->getMethods()['baz2']->getHttpMethods());
 
 	Assert::equal(
 		[

--- a/tests/cases/Schema/SchemaBuilderTest.php
+++ b/tests/cases/Schema/SchemaBuilderTest.php
@@ -1,0 +1,163 @@
+<?php declare(strict_types = 1);
+
+require_once __DIR__ . '/../../bootstrap.php';
+
+use Apitte\Core\Schema\Builder\SchemaBuilder;
+use Apitte\Core\Schema\Endpoint;
+use Apitte\Core\Schema\Hierarchy\ControllerMethodPair;
+use Apitte\Core\Schema\Hierarchy\HierarchyBuilder;
+use Apitte\Core\Utils\Helpers;
+use Tester\Assert;
+use Tester\TestCase;
+
+class SchemaBuilderTest extends TestCase
+{
+
+	public function testCorrectOrder(): void
+	{
+		$builder = new SchemaBuilder();
+
+		$this->addGetAlphabeticallyFirstEndpoint($builder);
+		$this->addGetUsersSomethingEndpoint($builder);
+		$this->addGetUsersIdEndpoint($builder);
+		$this->addPutPatchUsersIdEndpoint($builder);
+		$this->addGetUsersEndpoint($builder);
+		$this->addGetIdUsersEndpoint($builder);
+		$this->addCombinedRootEndpoint($builder);
+
+		$hierarchyBuilder = new HierarchyBuilder($builder->getControllers());
+		$this->makeAssertions($hierarchyBuilder);
+	}
+
+	public function testReverseOrder(): void
+	{
+		$builder = new SchemaBuilder();
+
+		$this->addCombinedRootEndpoint($builder);
+		$this->addGetIdUsersEndpoint($builder);
+		$this->addGetUsersEndpoint($builder);
+		$this->addPutPatchUsersIdEndpoint($builder);
+		$this->addGetUsersIdEndpoint($builder);
+		$this->addGetUsersSomethingEndpoint($builder);
+		$this->addGetAlphabeticallyFirstEndpoint($builder);
+
+		$hierarchyBuilder = new HierarchyBuilder($builder->getControllers());
+		$this->makeAssertions($hierarchyBuilder);
+	}
+
+	public function testShuffledOrder(): void
+	{
+		$builder = new SchemaBuilder();
+
+		$this->addGetUsersEndpoint($builder);
+		$this->addPutPatchUsersIdEndpoint($builder);
+		$this->addGetUsersIdEndpoint($builder);
+		$this->addCombinedRootEndpoint($builder);
+		$this->addGetAlphabeticallyFirstEndpoint($builder);
+		$this->addGetUsersSomethingEndpoint($builder);
+		$this->addGetIdUsersEndpoint($builder);
+
+		$hierarchyBuilder = new HierarchyBuilder($builder->getControllers());
+		$this->makeAssertions($hierarchyBuilder);
+	}
+
+	private function makeAssertions(HierarchyBuilder $builder): void
+	{
+		$endpoints = $builder->getSortedEndpoints();
+
+		// Ensure all endpoints are tested - always number is incremented an assertion should be added
+		Assert::count(7, $endpoints);
+
+		// Independently on order in which are endpoints added they should be outputted always in predefined order
+		Assert::same('GET /alphabetically-first', $this->buildPath($endpoints[0]));
+		Assert::same('GET /users/something', $this->buildPath($endpoints[1]));
+		Assert::same('GET /users/{id}', $this->buildPath($endpoints[2]));
+		Assert::same('PUT, PATCH /users/{id}', $this->buildPath($endpoints[3]));
+		Assert::same('GET /users', $this->buildPath($endpoints[4]));
+		Assert::same('GET /{id}/users', $this->buildPath($endpoints[5]));
+		Assert::same('GET, POST, PUT, DELETE, OPTIONS, PATCH /', $this->buildPath($endpoints[6]));
+	}
+
+	private function addGetUsersSomethingEndpoint(SchemaBuilder $builder): void
+	{
+		$controller = $builder->addController('getUsersSomething');
+		$controller->setPath('users');
+		$method = $controller->addMethod('getUsersSomething');
+		$method->setPath('something');
+		$method->setHttpMethods([Endpoint::METHOD_GET]);
+	}
+
+	private function addPutPatchUsersIdEndpoint(SchemaBuilder $builder): void
+	{
+		$controller = $builder->addController('putPatchUsersId');
+		$controller->setPath('users');
+		$method = $controller->addMethod('putPatchUsersId');
+		$method->setPath('{id}');
+		$method->setHttpMethods([Endpoint::METHOD_PUT, Endpoint::METHOD_PATCH]);
+	}
+
+	private function addGetUsersIdEndpoint(SchemaBuilder $builder): void
+	{
+		$controller = $builder->addController('getUsersId');
+		$controller->setPath('users');
+		$method = $controller->addMethod('getUsersId');
+		$method->setPath('{id}');
+		$method->setHttpMethods([Endpoint::METHOD_GET]);
+	}
+
+	private function addGetAlphabeticallyFirstEndpoint(SchemaBuilder $builder): void
+	{
+		$controller = $builder->addController('alphabeticallyFirst');
+		$controller->setPath('alphabetically-first');
+		$method = $controller->addMethod('alphabeticallyFirst');
+		$method->setPath('');
+		$method->setHttpMethods([Endpoint::METHOD_GET]);
+	}
+
+	private function addGetUsersEndpoint(SchemaBuilder $builder): void
+	{
+		$controller = $builder->addController('getUsers');
+		$controller->setPath('users');
+		$method = $controller->addMethod('getUsers');
+		$method->setPath('');
+		$method->setHttpMethods([Endpoint::METHOD_GET]);
+	}
+
+	private function addGetIdUsersEndpoint(SchemaBuilder $builder): void
+	{
+		$controller = $builder->addController('getIdUsers');
+		$controller->setPath('{id}');
+		$method = $controller->addMethod('getIdUsers');
+		$method->setPath('users');
+		$method->setHttpMethods([Endpoint::METHOD_GET]);
+	}
+
+	private function addCombinedRootEndpoint(SchemaBuilder $builder): void
+	{
+		$controller = $builder->addController('combinedRoot');
+		$controller->setPath('');
+		$method = $controller->addMethod('combinedRoot');
+		$method->setPath('');
+		$method->setHttpMethods(Endpoint::METHODS);
+	}
+
+	private function buildPath(ControllerMethodPair $endpoint): string
+	{
+		$controller = $endpoint->getController();
+		$method = $endpoint->getMethod();
+
+		$pathsList = array_merge(
+			$controller->getGroupPaths(),
+			[$controller->getPath()],
+			[$method->getPath()]
+		);
+		$path = implode('/', $pathsList);
+		$path = Helpers::slashless($path);
+		$path = '/' . trim($path, '/');
+
+		return implode(', ', $method->getHttpMethods()) . ' ' . $path;
+	}
+
+}
+
+(new SchemaBuilderTest())->run();

--- a/tests/cases/Schema/Serialization/ArraySerializator.phpt
+++ b/tests/cases/Schema/Serialization/ArraySerializator.phpt
@@ -31,17 +31,17 @@ test(function (): void {
 	$c1->addMethod('m1'); // Skipped, missing path
 
 	$m2 = $c1->addMethod('m2');
-	$m2->addMethod(Endpoint::METHOD_GET);
-	$m2->addMethod(Endpoint::METHOD_POST);
-	$m2->addMethod(Endpoint::METHOD_PUT);
+	$m2->addHttpMethod(Endpoint::METHOD_GET);
+	$m2->addHttpMethod(Endpoint::METHOD_POST);
+	$m2->addHttpMethod(Endpoint::METHOD_PUT);
 	$m2->setPath('m2-path');
 	$m2->setRequestMapper('A\Class\Which\Implements\Apitte\Core\Mapping\Request\IRequestEntity', true);
 	$m2->setResponseMapper('A\Class\Which\Implements\Apitte\Core\Mapping\Response\IResponseEntity');
 
 	$m3 = $c1->addMethod('m3');
 	$m3->setId('m3-id');
-	$m3->addMethod(Endpoint::METHOD_GET);
-	$m3->addMethod(Endpoint::METHOD_POST);
+	$m3->addHttpMethod(Endpoint::METHOD_GET);
+	$m3->addHttpMethod(Endpoint::METHOD_POST);
 	$m3->setPath('m3-path/{m3-p1}');
 	$m3->addTag('m3-t1');
 	$m3->addTag('m3-t2', 'm3-t2-value');

--- a/tests/cases/Schema/Validation/FullpathValidation.phpt
+++ b/tests/cases/Schema/Validation/FullpathValidation.phpt
@@ -22,18 +22,18 @@ test(function (): void {
 	$c1->setPath('foo2');
 	$c1m1 = $c1->addMethod('method');
 	$c1m1->setPath('foo3');
-	$c1m1->addMethod(Endpoint::METHOD_GET);
-	$c1m1->addMethod(Endpoint::METHOD_POST);
-	$c1m1->addMethod(Endpoint::METHOD_PUT);
+	$c1m1->addHttpMethod(Endpoint::METHOD_GET);
+	$c1m1->addHttpMethod(Endpoint::METHOD_POST);
+	$c1m1->addHttpMethod(Endpoint::METHOD_PUT);
 
 	$c2 = $builder->addController('c2');
 	$c2->addGroupPath('bar1');
 	$c2->setPath('bar2');
 	$c2m2 = $c2->addMethod('method');
 	$c2m2->setPath('bar3');
-	$c2m2->addMethod(Endpoint::METHOD_GET);
-	$c2m2->addMethod(Endpoint::METHOD_POST);
-	$c2m2->addMethod(Endpoint::METHOD_PUT);
+	$c2m2->addHttpMethod(Endpoint::METHOD_GET);
+	$c2m2->addHttpMethod(Endpoint::METHOD_POST);
+	$c2m2->addHttpMethod(Endpoint::METHOD_PUT);
 
 	Assert::noError(function () use ($validation, $builder): void {
 		$validation->validate($builder);
@@ -50,18 +50,18 @@ test(function (): void {
 	$c1->setPath('foo2');
 	$c1m1 = $c1->addMethod('method');
 	$c1m1->setPath('foo3');
-	$c1m1->addMethod(Endpoint::METHOD_GET);
-	$c1m1->addMethod(Endpoint::METHOD_POST);
-	$c1m1->addMethod(Endpoint::METHOD_PUT);
+	$c1m1->addHttpMethod(Endpoint::METHOD_GET);
+	$c1m1->addHttpMethod(Endpoint::METHOD_POST);
+	$c1m1->addHttpMethod(Endpoint::METHOD_PUT);
 
 	$c2 = $builder->addController('c2');
 	$c2->addGroupPath('foo1');
 	$c2->setPath('foo2');
 	$c2m2 = $c2->addMethod('method');
 	$c2m2->setPath('foo3');
-	$c2m2->addMethod(Endpoint::METHOD_GET);
-	$c2m2->addMethod(Endpoint::METHOD_POST);
-	$c2m2->addMethod(Endpoint::METHOD_PUT);
+	$c2m2->addHttpMethod(Endpoint::METHOD_GET);
+	$c2m2->addHttpMethod(Endpoint::METHOD_POST);
+	$c2m2->addHttpMethod(Endpoint::METHOD_PUT);
 
 	Assert::exception(function () use ($validation, $builder): void {
 		$validation->validate($builder);

--- a/tests/cases/Schema/Validation/PathValidation.phpt
+++ b/tests/cases/Schema/Validation/PathValidation.phpt
@@ -46,7 +46,7 @@ test(function (): void {
 	$c1 = $builder->addController('c1');
 	$c1m1 = $c1->addMethod('foo1');
 	$c1m1->setPath('/{foo$}');
-	$c1m1->addMethod('GET');
+	$c1m1->addHttpMethod('GET');
 
 	Assert::exception(function () use ($builder): void {
 		$validator = new PathValidation();
@@ -61,7 +61,7 @@ test(function (): void {
 	$c1 = $builder->addController('c1');
 	$c1m1 = $c1->addMethod('foo1');
 	$c1m1->setPath('/{%foo}');
-	$c1m1->addMethod('GET');
+	$c1m1->addHttpMethod('GET');
 
 	Assert::exception(function () use ($builder): void {
 		$validator = new PathValidation();
@@ -76,7 +76,7 @@ test(function (): void {
 	$c1 = $builder->addController('c1');
 	$c1m1 = $c1->addMethod('foo1');
 	$c1m1->setPath('/{foo&&&bar}');
-	$c1m1->addMethod('GET');
+	$c1m1->addHttpMethod('GET');
 
 	Assert::exception(function () use ($builder): void {
 		$validator = new PathValidation();
@@ -91,7 +91,7 @@ test(function (): void {
 	$c1 = $builder->addController('c1');
 	$c1m1 = $c1->addMethod('foo1');
 	$c1m1->setPath('/{foo}/{bar}');
-	$c1m1->addMethod('GET');
+	$c1m1->addHttpMethod('GET');
 	try {
 		$validator = new PathValidation();
 		$validator->validate($builder);


### PR DESCRIPTION
Closes #69 

Schema now sorts all paths by priority and also alphabetically.
In future it may open way to hierarchical routing which would match individual parts of routes, slash by slash, instead of a single large regex.