### PR TITLE
Removed unused description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
     "php": "^7.2",
     "ext-json": "*",
     "contributte/phpdoc": "v0.3.0",
-    "contributte/psr7-http-message": "v0.6.0",
-    "nette/reflection": "~2.4"
+    "contributte/psr7-http-message": "v0.6.0"
   },
   "require-dev": {
     "mockery/mockery": "^1.1.0",

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -192,7 +192,6 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 			// Append method to scheme
 			$schemaMethod = $controller->addMethod($method->getName());
-			$schemaMethod->setDescription($method->getDescription());
 
 			// Iterate over all method annotations
 			foreach ($annotations as $annotation) {

--- a/src/DI/Loader/NeonLoader.php
+++ b/src/DI/Loader/NeonLoader.php
@@ -46,7 +46,6 @@ class NeonLoader implements ILoader
 			$method = $controller->addMethod($name);
 			$method->setId($settings['id'] ?? null);
 			$method->setPath($settings['path'] ?? '');
-			$method->setDescription($settings['description'] ?? '');
 			$method->addHttpMethods($settings['methods'] ?? []);
 			$method->addTags($settings['tags'] ?? []);
 			$method->setOpenApi($settings['openapi'] ?? []);

--- a/src/Schema/Builder/Controller/Method.php
+++ b/src/Schema/Builder/Controller/Method.php
@@ -16,9 +16,6 @@ final class Method
 	/** @var string|null */
 	private $id;
 
-	/** @var string|null */
-	private $description;
-
 	/** @var string[] */
 	private $httpMethods = [];
 
@@ -68,16 +65,6 @@ final class Method
 	public function setId(?string $id): void
 	{
 		$this->id = $id;
-	}
-
-	public function getDescription(): ?string
-	{
-		return $this->description;
-	}
-
-	public function setDescription(?string $description): void
-	{
-		$this->description = $description;
 	}
 
 	/**

--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -41,9 +41,6 @@ final class Endpoint
 	/** @var EndpointHandler */
 	private $handler;
 
-	/** @var string|null */
-	private $description;
-
 	/** @var EndpointParameter[] */
 	private $parameters = [];
 
@@ -131,16 +128,6 @@ final class Endpoint
 	public function getHandler(): EndpointHandler
 	{
 		return $this->handler;
-	}
-
-	public function getDescription(): ?string
-	{
-		return $this->description;
-	}
-
-	public function setDescription(?string $description): void
-	{
-		$this->description = $description;
 	}
 
 	/**

--- a/src/Schema/Serialization/ArrayHydrator.php
+++ b/src/Schema/Serialization/ArrayHydrator.php
@@ -52,10 +52,6 @@ final class ArrayHydrator implements IHydrator
 		$endpoint->setMethods($data['methods']);
 		$endpoint->setMask($data['mask']);
 
-		if (isset($data['description'])) {
-			$endpoint->setDescription($data['description']);
-		}
-
 		if (isset($data['tags'])) {
 			foreach ($data['tags'] as $name => $value) {
 				$endpoint->addTag($name, $value);

--- a/src/Schema/Serialization/ArraySerializator.php
+++ b/src/Schema/Serialization/ArraySerializator.php
@@ -95,7 +95,6 @@ final class ArraySerializator implements ISerializator
 			'tags' => array_merge($controller->getTags(), $method->getTags()),
 			'methods' => $method->getHttpMethods(),
 			'mask' => $mask,
-			'description' => $method->getDescription(),
 			'parameters' => [],
 			'responses' => [],
 			'negotiations' => [],

--- a/tests/cases/Schema/Serialization/ArrayHydrator.phpt
+++ b/tests/cases/Schema/Serialization/ArrayHydrator.phpt
@@ -22,7 +22,6 @@ test(function (): void {
 			'tags' => ['c1-t1' => 'c1-t1-value'],
 			'methods' => ['GET', 'POST', 'PUT'],
 			'mask' => '/group1-path/group2-path/c1-path/m2-path',
-			'description' => null,
 			'parameters' => [],
 			'negotiations' => [],
 			'attributes' => ['pattern' => '/group1-path/group2-path/c1-path/m2-path'],
@@ -43,7 +42,6 @@ test(function (): void {
 			'tags' => ['c1-t1' => 'c1-t1-value', 'm3-t1' => null, 'm3-t2' => 'm3-t2-value'],
 			'methods' => ['GET', 'POST'],
 			'mask' => '/group1-path/group2-path/c1-path/m3-path/{m3-p1}',
-			'description' => 'm3-description',
 			'parameters' => [
 				'm3-p1' => [
 					'name' => 'm3-p1',
@@ -94,7 +92,6 @@ test(function (): void {
 	Assert::same('/group1-path/group2-path/c1-path/m2-path', $endpoint1->getAttribute('pattern'));
 	Assert::same(null, $endpoint1->getAttribute('missing'));
 	Assert::same('#/group1-path/group2-path/c1-path/m2-path$#', $endpoint1->getPattern());
-	Assert::same(null, $endpoint1->getDescription());
 	Assert::same([], $endpoint1->getParameters());
 	Assert::same([], $endpoint1->getNegotiations());
 
@@ -118,7 +115,6 @@ test(function (): void {
 	Assert::same('/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)', $endpoint2->getAttribute('pattern'));
 	Assert::same(null, $endpoint2->getAttribute('missing'));
 	Assert::same('#/group1-path/group2-path/c1-path/m3-path/(?P<m3-p1>[^/]+)(json|xml)?$#U', $endpoint2->getPattern());
-	Assert::same('m3-description', $endpoint2->getDescription());
 
 	Assert::same(null, $endpoint2->getRequestBody());
 

--- a/tests/cases/Schema/Serialization/ArraySerializator.phpt
+++ b/tests/cases/Schema/Serialization/ArraySerializator.phpt
@@ -43,7 +43,6 @@ test(function (): void {
 	$m3->setPath('m3-path/{m3-p1}');
 	$m3->addTag('m3-t1');
 	$m3->addTag('m3-t2', 'm3-t2-value');
-	$m3->setDescription('m3-description');
 
 	$m3rb = new MethodRequestBody();
 	$m3rb->setRequired(true);
@@ -82,7 +81,6 @@ test(function (): void {
 			'tags' => ['c1-t1' => 'c1-t1-value'],
 			'methods' => ['GET', 'POST', 'PUT'],
 			'mask' => '/group1-path/group2-path/c1-path/m2-path',
-			'description' => null,
 			'parameters' => [],
 			'responses' => [],
 			'negotiations' => [],
@@ -98,7 +96,6 @@ test(function (): void {
 			'tags' => ['c1-t1' => 'c1-t1-value', 'm3-t1' => null, 'm3-t2' => 'm3-t2-value'],
 			'methods' => ['GET', 'POST'],
 			'mask' => '/group1-path/group2-path/c1-path/m3-path/{m3-p1}',
-			'description' => 'm3-description',
 			'parameters' => [
 				'm3-p1' => [
 					'name' => 'm3-p1',


### PR DESCRIPTION
`@description` parsed by nette/reflection was useless since doctrine annotations were introduced, doctrine throw exception if an unknown annotation (even without brackets) is used.
I removed it as it's not used anywhere and for openapi description and summary we have `@OpenApi` annotation