### PR TITLE
Fix for "Wrong parameters for SnapshotException"

### DIFF
--- a/src/Exception/Runtime/SnapshotException.php
+++ b/src/Exception/Runtime/SnapshotException.php
@@ -21,7 +21,7 @@ class SnapshotException extends RuntimeException
 
 	public function __construct(Throwable $exception, ApiRequest $request, ApiResponse $response)
 	{
-		parent::__construct($exception->getMessage(), $exception->getCode(), $exception);
+		parent::__construct($exception->getMessage(), is_string($exception->getCode()) ? -1 : $exception->getCode(), $exception);
 		$this->request = $request;
 		$this->response = $response;
 	}


### PR DESCRIPTION
DB error codes may be (and in PostgreSQL they are) strings (instead of required long).

It solves following error:
```Error: Wrong parameters for Apitte\Core\Exception\Runtime\SnapshotException([string $message [, long $code [, Throwable $previous = NULL]]]) in ...```