### PR TITLE
Removed final from class \Apitte\Core\Annotation\Controller\RequestPa…

### DIFF
--- a/src/Annotation/Controller/RequestParameters.php
+++ b/src/Annotation/Controller/RequestParameters.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Annotations\AnnotationException;
  * @Annotation
  * @Target("METHOD")
  */
-final class RequestParameters
+class RequestParameters
 {
 
 	/** @var RequestParameter[] */


### PR DESCRIPTION
Hello, 
thanks to commit 1d31ac2cc16350a47a158fe8880762e13820bb43 and removing `final` from class `\Apitte\Core\Annotation\Controller\RequestParameters` I can simple create reusable parameters classes. Simple example can be paging of results. When I need only create super simple class with my predefined params.  

```php
<?php

declare(strict_types=1);

namespace Monitory\Device\Annotations;
use Apitte\Core\Annotation\Controller\RequestParameter;
use Apitte\Core\Annotation\Controller\RequestParameters;
use Doctrine\Common\Annotations\Annotation\Target;

/**
 * @Annotation
 * @Target("METHOD")
 *
 * @package Monitory\Device\Annotations
 */
class Pageable extends RequestParameters
{
	/**
	 * @param mixed[] $values
	 */
	public function __construct()
	{
		parent::__construct([
			'value' => [
				new RequestParameter([
					'name' => 'take',
					'type' => 'int',
					'in' => 'query',
					'required' => false,
				]),
				new RequestParameter([
					'name' => 'skip',
					'type' => 'int',
					'in' => 'query',
					'required' => false,
				]),
			]
		]);
	}
}

```

and now use it as new annotation

```php
<?php

declare(strict_types=1);

namespace Monitory\Device\Controller;

use Apitte\Core\Http\ApiRequest;
use Apitte\Core\Http\ApiResponse;
use Apitte\Core\Annotation\Controller\Path;
use Apitte\Core\Annotation\Controller\Method;
use Monitory\Device\Annotations\Pageable;

/**
 * @Path("/playlist")
 */
class PlaylistController extends BaseV1Controller
{

	/**
	 * @Path("/")
	 * @Method("GET")

	 * @Pageable()
	 */
	public function index(ApiRequest $request, ApiResponse $response): ApiResponse
	{
		return $response->writeJsonBody([$request->getParameters()]);
	}

}

```