### PR TITLE
Pass ApiRequest to ErrorHandler

### DIFF
--- a/src/Application/BaseApplication.php
+++ b/src/Application/BaseApplication.php
@@ -2,6 +2,7 @@
 
 namespace Apitte\Core\Application;
 
+use Apitte\Core\Dispatcher\DispatchError;
 use Apitte\Core\ErrorHandler\IErrorHandler;
 use Apitte\Core\Http\ApiRequest;
 use Apitte\Core\Http\ApiResponse;
@@ -34,7 +35,7 @@ abstract class BaseApplication implements IApplication
 		try {
 			$response = $this->dispatch($request);
 		} catch (Throwable $exception) {
-			$response = $this->errorHandler->handle($exception);
+			$response = $this->errorHandler->handle(new DispatchError($exception, $request));
 		}
 
 		$this->sendResponse($response);

--- a/src/Dispatcher/DispatchError.php
+++ b/src/Dispatcher/DispatchError.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Apitte\Core\Dispatcher;
+
+use Apitte\Core\Http\ApiRequest;
+use Throwable;
+
+class DispatchError
+{
+
+	/** @var Throwable */
+	protected $error;
+
+	/** @var ApiRequest */
+	protected $request;
+
+	public function __construct(Throwable $error, ApiRequest $request)
+	{
+		$this->error = $error;
+		$this->request = $request;
+	}
+
+	public function getError(): Throwable
+	{
+		return $this->error;
+	}
+
+	public function getRequest(): ApiRequest
+	{
+		return $this->request;
+	}
+
+}

--- a/src/ErrorHandler/IErrorHandler.php
+++ b/src/ErrorHandler/IErrorHandler.php
@@ -2,8 +2,8 @@
 
 namespace Apitte\Core\ErrorHandler;
 
+use Apitte\Core\Dispatcher\DispatchError;
 use Apitte\Core\Http\ApiResponse;
-use Throwable;
 
 interface IErrorHandler
 {
@@ -11,6 +11,6 @@ interface IErrorHandler
 	/**
 	 * Log error and generate response
 	 */
-	public function handle(Throwable $error): ApiResponse;
+	public function handle(DispatchError $dispatchError): ApiResponse;
 
 }

--- a/src/ErrorHandler/PsrLogErrorHandler.php
+++ b/src/ErrorHandler/PsrLogErrorHandler.php
@@ -2,13 +2,13 @@
 
 namespace Apitte\Core\ErrorHandler;
 
+use Apitte\Core\Dispatcher\DispatchError;
 use Apitte\Core\Exception\Api\ServerErrorException;
 use Apitte\Core\Exception\ApiException;
 use Apitte\Core\Exception\Runtime\SnapshotException;
 use Apitte\Core\Http\ApiResponse;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-use Throwable;
 
 class PsrLogErrorHandler extends SimpleErrorHandler
 {
@@ -21,10 +21,9 @@ class PsrLogErrorHandler extends SimpleErrorHandler
 		$this->logger = $logger;
 	}
 
-	public function handle(Throwable $error): ApiResponse
+	public function handle(DispatchError $dispatchError): ApiResponse
 	{
-		// Unwrap error from snapshot for logging
-		$originalError = $error;
+		$error = $dispatchError->getError();
 
 		if ($error instanceof SnapshotException) {
 			$error = $error->getPrevious();
@@ -42,7 +41,7 @@ class PsrLogErrorHandler extends SimpleErrorHandler
 			$this->logger->log($level, $previous->getMessage(), ['exception' => $previous]);
 		}
 
-		return parent::handle($originalError);
+		return parent::handle($dispatchError);
 	}
 
 }

--- a/src/ErrorHandler/SimpleErrorHandler.php
+++ b/src/ErrorHandler/SimpleErrorHandler.php
@@ -2,6 +2,7 @@
 
 namespace Apitte\Core\ErrorHandler;
 
+use Apitte\Core\Dispatcher\DispatchError;
 use Apitte\Core\Exception\Api\ServerErrorException;
 use Apitte\Core\Exception\ApiException;
 use Apitte\Core\Exception\Runtime\SnapshotException;
@@ -22,8 +23,10 @@ class SimpleErrorHandler implements IErrorHandler
 		$this->catchException = $catchException;
 	}
 
-	public function handle(Throwable $error): ApiResponse
+	public function handle(DispatchError $dispatchError): ApiResponse
 	{
+		$error = $dispatchError->getError();
+
 		// Rethrow error if it should not be catch (debug only)
 		if (!$this->catchException) {
 			// Unwrap exception from snapshot


### PR DESCRIPTION
Is there a reason to not pass ApiRequest to ErrorHandler?

I have two use cases, where i need ApiRequest in ErrorHandler
1) log the request on error
2) cors: i need the request to correctly setup Access-Control-Allow-Origin