### PR TITLE
Possibility of passing ConstraintValidatorFactory to SymfonyValidator

### DIFF
--- a/.docs/mapping.md
+++ b/.docs/mapping.md
@@ -198,3 +198,13 @@ final class UserFilter extends BasicEntity
 
 }
 ```
+
+If you want to use [custom validation contstraints](https://symfony.com/doc/current/validation/custom_constraint.html) with support of Nette DI, you should also install [contributte/validator](https://github.com/contributte/validator).
+
+```yaml
+api:
+    plugins:
+        Apitte\Core\DI\Plugin\CoreMappingPlugin:
+            request:
+                validator: Apitte\Core\Mapping\Validator\SymfonyValidator(..., Contributte\Validator\ContainerConstraintValidatorFactory())
+```

--- a/.docs/mapping.md
+++ b/.docs/mapping.md
@@ -206,5 +206,5 @@ api:
     plugins:
         Apitte\Core\DI\Plugin\CoreMappingPlugin:
             request:
-                validator: Apitte\Core\Mapping\Validator\SymfonyValidator(..., Contributte\Validator\ContainerConstraintValidatorFactory())
+                validator: Apitte\Core\Mapping\Validator\SymfonyValidator()::setConstraintValidatorFactory(Contributte\Validator\ContainerConstraintValidatorFactory())
 ```

--- a/src/Mapping/Validator/SymfonyValidator.php
+++ b/src/Mapping/Validator/SymfonyValidator.php
@@ -15,14 +15,20 @@ class SymfonyValidator implements IEntityValidator
 	/** @var Reader */
 	private $reader;
 
-	/** @var ConstraintValidatorFactoryInterface|null */
+	/** @var ConstraintValidatorFactoryInterface */
 	private $constraintValidatorFactory;
 
-	public function __construct(Reader $reader, ?ConstraintValidatorFactoryInterface $constraintValidatorFactory = null)
+	public function __construct(Reader $reader)
 	{
 		$this->reader = $reader;
-		$this->constraintValidatorFactory = $constraintValidatorFactory;
 		AnnotationReader::addGlobalIgnoredName('mapping');
+	}
+
+	public function setConstraintValidatorFactory(ConstraintValidatorFactoryInterface $constraintValidatorFactory): self
+	{
+		$this->constraintValidatorFactory = $constraintValidatorFactory;
+
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
It would be nice, to have possibility of passing custom ConstraintValidatorFactory to SymfonyValidator like this

https://github.com/contributte/validator/blob/master/src/ContainerConstraintValidatorFactory.php

to be able to use DI injections in custom validators.