### PR TITLE
BasicEntity: map GET parameters to DELETE method

### DIFF
--- a/src/Mapping/Request/BasicEntity.php
+++ b/src/Mapping/Request/BasicEntity.php
@@ -28,7 +28,7 @@ abstract class BasicEntity extends AbstractEntity
 			return $this->fromBodyRequest($request);
 		}
 
-		if ($request->getMethod() === Endpoint::METHOD_GET) {
+		if (in_array($request->getMethod(), [Endpoint::METHOD_GET, Endpoint::METHOD_DELETE], true)) {
 			return $this->fromGetRequest($request);
 		}
 

--- a/tests/fixtures/Mapping/Request/NotEmptyEntity.php
+++ b/tests/fixtures/Mapping/Request/NotEmptyEntity.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Mapping\Request;
+
+use Apitte\Core\Mapping\Request\BasicEntity;
+
+class NotEmptyEntity extends BasicEntity
+{
+
+	/** @var int */
+	public $foo;
+
+}


### PR DESCRIPTION
AFAIK DELETE method does not have body, so we can map entity to GET parameters.