### PR TITLE
[PHP 8.0] Pre-attributes - update annotations to named arguments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "php": ">=7.2",
     "ext-json": "*",
     "contributte/psr7-http-message": "~0.7.0",
-    "doctrine/annotations": "^1.8.0",
+    "doctrine/annotations": "^1.13",
     "nette/utils": "^3.0.3"
   },
   "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,7 +21,7 @@ parameters:
 		- '#^Call to static method from\(\) on an unknown class Apitte\\Negotiation\\Http\\#'
 
 		# Phpstan bug
-		- '#^Parameter \#1 \$callback of function call_user_func expects callable\(\)\: mixed, array\(Apitte\\Core\\UI\\Controller\\IController, string\) given\.$#'
+		- '#^Parameter \#1 (.*?) of function call_user_func expects callable\(\)\: mixed, array\(Apitte\\Core\\UI\\Controller\\IController, string\) given\.$#'
 		- message: '#^Parameter \#1 \$argument of class ReflectionClass constructor expects class-string<T of object>|T of object, string given\.$#'
 		  path: %currentWorkingDirectory%/src/DI/Loader/DoctrineAnnotationLoader.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,7 +21,7 @@ parameters:
 		- '#^Call to static method from\(\) on an unknown class Apitte\\Negotiation\\Http\\#'
 
 		# Phpstan bug
-		- '#^Parameter \#1 \$function of function call_user_func expects callable\(\)\: mixed, array\(Apitte\\Core\\UI\\Controller\\IController, string\) given\.$#'
+		- '#^Parameter \#1 \$callback of function call_user_func expects callable\(\)\: mixed, array\(Apitte\\Core\\UI\\Controller\\IController, string\) given\.$#'
 		- message: '#^Parameter \#1 \$argument of class ReflectionClass constructor expects class-string<T of object>|T of object, string given\.$#'
 		  path: %currentWorkingDirectory%/src/DI/Loader/DoctrineAnnotationLoader.php
 

--- a/src/Annotation/Controller/Id.php
+++ b/src/Annotation/Controller/Id.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target({"CLASS","METHOD"})
+ * @NamedArgumentConstructor()
  */
 final class Id
 {
@@ -15,21 +17,13 @@ final class Id
 	/** @var string */
 	private $name;
 
-	/**
-	 * @param array<string, mixed|null> $values
-	 */
-	public function __construct(array $values)
+	public function __construct(string $name)
 	{
-		if (!isset($values['value'])) {
-			throw new AnnotationException('No @Id given');
-		}
-
-		$value = $values['value'];
-		if (empty($value)) {
+		if ($name === '') {
 			throw new AnnotationException('Empty @Id given');
 		}
 
-		$this->name = $value;
+		$this->name = $name;
 	}
 
 	public function getName(): string

--- a/src/Annotation/Controller/Method.php
+++ b/src/Annotation/Controller/Method.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor()
  */
 final class Method
 {
@@ -16,21 +18,16 @@ final class Method
 	private $methods = [];
 
 	/**
-	 * @param mixed[] $values
+	 * @param string[]|string $methods
 	 */
-	public function __construct(array $values)
+	public function __construct($methods)
 	{
-		if (!isset($values['value'])) {
-			throw new AnnotationException('No @Method given');
-		}
-
-		$methods = $values['value'];
 		if (empty($methods)) {
 			throw new AnnotationException('Empty @Method given');
 		}
 
 		// Wrap single given method into array
-		if (!is_array($methods)) {
+		if (! is_array($methods)) {
 			$methods = [$methods];
 		}
 

--- a/src/Annotation/Controller/Negotiation.php
+++ b/src/Annotation/Controller/Negotiation.php
@@ -2,12 +2,13 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
-use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target("ANNOTATION")
+ * @NamedArgumentConstructor()
  */
 final class Negotiation
 {
@@ -21,18 +22,11 @@ final class Negotiation
 	/** @var string|null */
 	private $renderer;
 
-	/**
-	 * @param mixed[] $values
-	 */
-	public function __construct(array $values)
+	public function __construct(string $suffix, bool $default = false, ?string $renderer = null)
 	{
-		if (!isset($values['suffix'])) {
-			throw new AnnotationException('Suffix is required at @Negotiation');
-		}
-
-		$this->suffix = $values['suffix'];
-		$this->default = $values['default'] ?? false;
-		$this->renderer = $values['renderer'] ?? null;
+		$this->suffix = $suffix;
+		$this->default = $default;
+		$this->renderer = $renderer;
 	}
 
 	public function getSuffix(): string

--- a/src/Annotation/Controller/Negotiations.php
+++ b/src/Annotation/Controller/Negotiations.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor()
  */
 final class Negotiations
 {
@@ -16,16 +18,11 @@ final class Negotiations
 	private $negotiations = [];
 
 	/**
-	 * @param mixed[] $values
+	 * @param Negotiation[]|Negotiation $negotiations
 	 */
-	public function __construct(array $values)
+	public function __construct($negotiations)
 	{
-		if (!isset($values['value'])) {
-			throw new AnnotationException('No @Negotiation given in @Negotiations');
-		}
-
-		$negotiations = $values['value'];
-		if ($negotiations === []) {
+		if (empty($negotiations)) {
 			throw new AnnotationException('Empty @Negotiations given');
 		}
 

--- a/src/Annotation/Controller/OpenApi.php
+++ b/src/Annotation/Controller/OpenApi.php
@@ -2,11 +2,13 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 
 /**
  * @Annotation
  * @Target({"CLASS","METHOD"})
+ * @NamedArgumentConstructor()
  */
 final class OpenApi
 {
@@ -14,12 +16,9 @@ final class OpenApi
 	/** @var string */
 	private $data;
 
-	/**
-	 * @param mixed[] $data
-	 */
-	public function __construct(array $data)
+	public function __construct(string $data)
 	{
-		$this->data = $this->purifyDocblock($data['value']);
+		$this->data = $this->purifyDocblock($data);
 	}
 
 	public function getData(): string

--- a/src/Annotation/Controller/Path.php
+++ b/src/Annotation/Controller/Path.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target({"CLASS","METHOD"})
+ * @NamedArgumentConstructor()
  */
 final class Path
 {
@@ -15,21 +17,13 @@ final class Path
 	/** @var string */
 	private $path;
 
-	/**
-	 * @param mixed[] $values
-	 */
-	public function __construct(array $values)
+	public function __construct(string $path)
 	{
-		if (!isset($values['value'])) {
-			throw new AnnotationException('No @Path given');
-		}
-
-		$value = $values['value'];
-		if (empty($value)) {
+		if ($path === '') {
 			throw new AnnotationException('Empty @Path given');
 		}
 
-		$this->path = $value;
+		$this->path = $path;
 	}
 
 	public function getPath(): string

--- a/src/Annotation/Controller/RequestBody.php
+++ b/src/Annotation/Controller/RequestBody.php
@@ -2,11 +2,13 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor()
  */
 final class RequestBody
 {
@@ -23,15 +25,12 @@ final class RequestBody
 	/** @var bool */
 	private $validation;
 
-	/**
-	 * @param mixed[] $values
-	 */
-	public function __construct(array $values)
+	public function __construct(?string $description = null, ?string $entity = null, bool $required = false, bool $validation = true)
 	{
-		$this->description = $values['description'] ?? null;
-		$this->entity = $values['entity'] ?? null;
-		$this->required = $values['required'] ?? false;
-		$this->validation = $values['validation'] ?? true;
+		$this->description = $description;
+		$this->entity = $entity;
+		$this->required = $required;
+		$this->validation = $validation;
 	}
 
 	public function getEntity(): ?string

--- a/src/Annotation/Controller/RequestParameter.php
+++ b/src/Annotation/Controller/RequestParameter.php
@@ -2,7 +2,6 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
-use Apitte\Core\Schema\EndpointParameter;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;

--- a/src/Annotation/Controller/RequestParameter.php
+++ b/src/Annotation/Controller/RequestParameter.php
@@ -3,12 +3,14 @@
 namespace Apitte\Core\Annotation\Controller;
 
 use Apitte\Core\Schema\EndpointParameter;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target("ANNOTATION")
+ * @NamedArgumentConstructor()
  */
 final class RequestParameter
 {
@@ -34,36 +36,31 @@ final class RequestParameter
 	/** @var bool */
 	private $allowEmpty;
 
-	/**
-	 * @param mixed[] $values
-	 */
-	public function __construct(array $values)
+	public function __construct(
+		string $name,
+		string $type,
+		bool $required = true,
+		bool $allowEmpty = false,
+		bool $deprecated = false,
+		?string $description = null,
+		string $in = EndpointParameter::IN_PATH
+	)
 	{
-		if (!isset($values['name'])) {
-			throw new AnnotationException('No @RequestParameter name given');
-		}
-
-		$name = $values['name'];
-		if (empty($name)) {
+		if ($name === '') {
 			throw new AnnotationException('Empty @RequestParameter name given');
 		}
 
-		if (!isset($values['type'])) {
-			throw new AnnotationException('No @RequestParameter type given');
-		}
-
-		$type = $values['type'];
-		if (empty($type)) {
+		if ($type === '') {
 			throw new AnnotationException('Empty @RequestParameter type given');
 		}
 
 		$this->name = $name;
 		$this->type = $type;
-		$this->required = $values['required'] ?? true;
-		$this->allowEmpty = $values['allowEmpty'] ?? false;
-		$this->deprecated = $values['deprecated'] ?? false;
-		$this->description = $values['description'] ?? null;
-		$this->in = $values['in'] ?? EndpointParameter::IN_PATH;
+		$this->required = $required;
+		$this->allowEmpty = $allowEmpty;
+		$this->deprecated = $deprecated;
+		$this->description = $description;
+		$this->in = $in;
 	}
 
 	public function getName(): string

--- a/src/Annotation/Controller/RequestParameter.php
+++ b/src/Annotation/Controller/RequestParameter.php
@@ -39,11 +39,11 @@ final class RequestParameter
 	public function __construct(
 		string $name,
 		string $type,
+		string $in,
 		bool $required = true,
 		bool $allowEmpty = false,
 		bool $deprecated = false,
-		?string $description = null,
-		string $in = EndpointParameter::IN_PATH
+		?string $description = null
 	)
 	{
 		if ($name === '') {

--- a/src/Annotation/Controller/RequestParameters.php
+++ b/src/Annotation/Controller/RequestParameters.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor()
  */
 class RequestParameters
 {
@@ -16,16 +18,11 @@ class RequestParameters
 	private $parameters = [];
 
 	/**
-	 * @param mixed[] $values
+	 * @param RequestParameter[]|RequestParameter $parameters
 	 */
-	public function __construct(array $values)
+	public function __construct($parameters)
 	{
-		if (!isset($values['value'])) {
-			throw new AnnotationException('No @RequestParameter given in @RequestParameters');
-		}
-
-		$parameters = $values['value'];
-		if ($parameters === []) {
+		if (empty($parameters)) {
 			throw new AnnotationException('Empty @RequestParameters given');
 		}
 
@@ -35,7 +32,7 @@ class RequestParameters
 		}
 
 		$takenNames = [];
-		/** @var RequestParameter $parameter */
+
 		foreach ($parameters as $parameter) {
 			if (!isset($takenNames[$parameter->getIn()][$parameter->getName()])) {
 				$takenNames[$parameter->getIn()][$parameter->getName()] = $parameter;

--- a/src/Annotation/Controller/Response.php
+++ b/src/Annotation/Controller/Response.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target("ANNOTATION")
+ * @NamedArgumentConstructor()
  */
 final class Response
 {
@@ -21,22 +23,14 @@ final class Response
 	/** @var string|null */
 	private $entity;
 
-	/**
-	 * @param mixed[] $values
-	 */
-	public function __construct(array $values)
+	public function __construct(string $description, string $code = 'default', ?string $entity = null)
 	{
-		if (!isset($values['description'])) {
-			throw new AnnotationException('No @Response description given');
-		}
-
-		$description = $values['description'];
 		if (empty($description)) {
 			throw new AnnotationException('Empty @Response description given');
 		}
 
-		$this->code = $values['code'] ?? 'default';
-		$this->entity = $values['entity'] ?? null;
+		$this->code = $code;
+		$this->entity = $entity;
 		$this->description = $description;
 	}
 

--- a/src/Annotation/Controller/Responses.php
+++ b/src/Annotation/Controller/Responses.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @NamedArgumentConstructor()
  */
 final class Responses
 {
@@ -16,16 +18,11 @@ final class Responses
 	private $responses = [];
 
 	/**
-	 * @param mixed[] $values
+	 * @param Response[]|Response $responses
 	 */
-	public function __construct(array $values)
+	public function __construct($responses)
 	{
-		if (!isset($values['value'])) {
-			throw new AnnotationException('No @Response given in @Responses');
-		}
-
-		$responses = $values['value'];
-		if ($responses === []) {
+		if (empty($responses)) {
 			throw new AnnotationException('Empty @Responses given');
 		}
 
@@ -35,6 +32,7 @@ final class Responses
 		}
 
 		$takenCodes = [];
+
 		/** @var Response $response */
 		foreach ($responses as $response) {
 			if (!isset($takenCodes[$response->getCode()])) {

--- a/src/Annotation/Controller/Tag.php
+++ b/src/Annotation/Controller/Tag.php
@@ -2,12 +2,14 @@
 
 namespace Apitte\Core\Annotation\Controller;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\Annotation\Target;
 use Doctrine\Common\Annotations\AnnotationException;
 
 /**
  * @Annotation
  * @Target({"CLASS", "METHOD"})
+ * @NamedArgumentConstructor()
  */
 final class Tag
 {
@@ -18,26 +20,14 @@ final class Tag
 	/** @var string|null */
 	private $value;
 
-	/**
-	 * @param mixed[] $values
-	 */
-	public function __construct(array $values)
+	public function __construct(string $name, ?string $value = null)
 	{
-		if (isset($values['value']) && !isset($values['name'])) {
-			$values['name'] = $values['value'];
-		}
-
-		if (!isset($values['name'])) {
-			throw new AnnotationException('No @Tag name given');
-		}
-
-		$name = $values['name'];
-		if (empty($name)) {
+		if ($name === '') {
 			throw new AnnotationException('Empty @Tag name given');
 		}
 
 		$this->name = $name;
-		$this->value = $values['value'] ?? null;
+		$this->value = $value;
 	}
 
 	public function getName(): string

--- a/tests/cases/Annotation/Controller/Id.phpt
+++ b/tests/cases/Annotation/Controller/Id.phpt
@@ -12,21 +12,13 @@ use Tester\Assert;
 
 // Value
 test(function (): void {
-	$id = new Id([
-		'value' => 'id',
-	]);
+	$id = new Id('id');
 	Assert::same('id', $id->getName());
 });
 
 // Exception - no name
 test(function (): void {
 	Assert::exception(function (): void {
-		new Id([
-			'value' => '',
-		]);
+		new Id('');
 	}, AnnotationException::class, 'Empty @Id given');
-
-	Assert::exception(function (): void {
-		new Id([]);
-	}, AnnotationException::class, 'No @Id given');
 });

--- a/tests/cases/Annotation/Controller/Method.phpt
+++ b/tests/cases/Annotation/Controller/Method.phpt
@@ -12,10 +12,10 @@ require_once __DIR__ . '/../../../bootstrap.php';
 
 // Ok
 test(function (): void {
-	$method = new Method(['value' => 'GET']);
+	$method = new Method('GET');
 	Assert::equal(['GET'], $method->getMethods());
 
-	$method = new Method(['value' => ['GET', 'POST']]);
+	$method = new Method(['GET', 'POST']);
 	Assert::equal(['GET', 'POST'], $method->getMethods());
 });
 
@@ -23,13 +23,9 @@ test(function (): void {
 test(function (): void {
 	Assert::exception(function (): void {
 		new Method([]);
-	}, AnnotationException::class, 'No @Method given');
-
-	Assert::exception(function (): void {
-		new Method(['value' => []]);
 	}, AnnotationException::class, 'Empty @Method given');
 
 	Assert::exception(function (): void {
-		new Method(['value' => '']);
+		new Method('');
 	}, AnnotationException::class, 'Empty @Method given');
 });

--- a/tests/cases/Annotation/Controller/Negotiation.phpt
+++ b/tests/cases/Annotation/Controller/Negotiation.phpt
@@ -7,26 +7,14 @@
 require_once __DIR__ . '/../../../bootstrap.php';
 
 use Apitte\Core\Annotation\Controller\Negotiation;
-use Doctrine\Common\Annotations\AnnotationException;
 use Tester\Assert;
 use Tests\Fixtures\Negotiation\FooRenderer;
 
 // Value
 test(function (): void {
-	$negotiation = new Negotiation([
-		'suffix' => 'json',
-		'default' => true,
-		'renderer' => FooRenderer::class,
-	]);
+	$negotiation = new Negotiation('json', true, FooRenderer::class);
 
 	Assert::same('json', $negotiation->getSuffix());
 	Assert::same(true, $negotiation->isDefault());
 	Assert::same(FooRenderer::class, $negotiation->getRenderer());
-});
-
-// Exception - suffix
-test(function (): void {
-	Assert::exception(function (): void {
-		new Negotiation([]);
-	}, AnnotationException::class, 'Suffix is required at @Negotiation');
 });

--- a/tests/cases/Annotation/Controller/Negotiations.phpt
+++ b/tests/cases/Annotation/Controller/Negotiations.phpt
@@ -14,20 +14,9 @@ use Tester\Assert;
 // OK
 test(function (): void {
 	$negotiations = new Negotiations([
-		'value' => [
-			$negotiation1 = new Negotiation([
-				'suffix' => 'json',
-				'default' => true,
-			]),
-			$negotiation2 = new Negotiation([
-				'suffix' => 'xml',
-				'default' => false,
-			]),
-			$negotiation3 = new Negotiation([
-				'suffix' => 'csv',
-				'default' => false,
-			]),
-		],
+		$negotiation1 = new Negotiation('json', true),
+		$negotiation2 = new Negotiation('xml', false),
+		$negotiation3 = new Negotiation('csv', false),
 	]);
 
 	Assert::same([$negotiation1, $negotiation2, $negotiation3], $negotiations->getNegotiations());
@@ -36,12 +25,6 @@ test(function (): void {
 // Exception - empty negotiations
 test(function (): void {
 	Assert::exception(function (): void {
-		new Negotiations([
-			'value' => [],
-		]);
-	}, AnnotationException::class, 'Empty @Negotiations given');
-
-	Assert::exception(function (): void {
 		new Negotiations([]);
-	}, AnnotationException::class, 'No @Negotiation given in @Negotiations');
+	}, AnnotationException::class, 'Empty @Negotiations given');
 });

--- a/tests/cases/Annotation/Controller/Path.phpt
+++ b/tests/cases/Annotation/Controller/Path.phpt
@@ -12,21 +12,13 @@ use Tester\Assert;
 
 // OK
 test(function (): void {
-	$path = new Path([
-		'value' => 'FakePath',
-	]);
+	$path = new Path('FakePath');
 	Assert::same('FakePath', $path->getPath());
 });
 
 // Exception - empty path
 test(function (): void {
 	Assert::exception(function (): void {
-		new Path([
-			'value' => '',
-		]);
+		new Path('');
 	}, AnnotationException::class, 'Empty @Path given');
-
-	Assert::exception(function (): void {
-		new Path([]);
-	}, AnnotationException::class, 'No @Path given');
 });

--- a/tests/cases/Annotation/Controller/RequestBody.phpt
+++ b/tests/cases/Annotation/Controller/RequestBody.phpt
@@ -12,18 +12,18 @@ use Tests\Fixtures\Mapping\Request\FooEntity;
 
 // OK
 test(function (): void {
-	$requestBody1 = new RequestBody([]);
+	$requestBody1 = new RequestBody();
 	Assert::same(null, $requestBody1->getEntity());
 	Assert::same(true, $requestBody1->isValidation());
 	Assert::same(null, $requestBody1->getDescription());
 	Assert::same(false, $requestBody1->isRequired());
 
-	$requestBody2 = new RequestBody([
-		'entity' => FooEntity::class,
-		'validation' => false,
-		'required' => true,
-		'description' => 'description',
-	]);
+	$requestBody2 = new RequestBody(
+		'description',
+		FooEntity::class,
+		true,
+		false
+	);
 	Assert::same(FooEntity::class, $requestBody2->getEntity());
 	Assert::same(false, $requestBody2->isValidation());
 	Assert::same('description', $requestBody2->getDescription());

--- a/tests/cases/Annotation/Controller/RequestParameter.phpt
+++ b/tests/cases/Annotation/Controller/RequestParameter.phpt
@@ -16,11 +16,11 @@ test(function (): void {
 	$requestParameter = new RequestParameter(
 		'Parameter',
 		EndpointParameter::TYPE_STRING,
+		EndpointParameter::IN_QUERY,
 		true,
 		false,
 		false,
-		'Desc',
-		EndpointParameter::IN_QUERY
+		'Desc'
 	);
 
 	Assert::same('Parameter', $requestParameter->getName());
@@ -32,6 +32,6 @@ test(function (): void {
 // Exception - no type
 test(function (): void {
 	Assert::exception(function (): void {
-		new RequestParameter('Param', '');
+		new RequestParameter('Param', '', EndpointParameter::IN_PATH);
 	}, AnnotationException::class, 'Empty @RequestParameter type given');
 });

--- a/tests/cases/Annotation/Controller/RequestParameter.phpt
+++ b/tests/cases/Annotation/Controller/RequestParameter.phpt
@@ -13,12 +13,15 @@ use Tester\Assert;
 
 // OK
 test(function (): void {
-	$requestParameter = new RequestParameter([
-		'name' => 'Parameter',
-		'description' => 'Desc',
-		'type' => EndpointParameter::TYPE_STRING,
-		'in' => EndpointParameter::IN_QUERY,
-	]);
+	$requestParameter = new RequestParameter(
+		'Parameter',
+		EndpointParameter::TYPE_STRING,
+		true,
+		false,
+		false,
+		'Desc',
+		EndpointParameter::IN_QUERY
+	);
 
 	Assert::same('Parameter', $requestParameter->getName());
 	Assert::same('Desc', $requestParameter->getDescription());
@@ -26,31 +29,9 @@ test(function (): void {
 	Assert::same(EndpointParameter::IN_QUERY, $requestParameter->getIn());
 });
 
-// Exception - no name
-test(function (): void {
-	Assert::exception(function (): void {
-		new RequestParameter([]);
-	}, AnnotationException::class, 'No @RequestParameter name given');
-
-	Assert::exception(function (): void {
-		new RequestParameter([
-			'name' => '',
-		]);
-	}, AnnotationException::class, 'Empty @RequestParameter name given');
-});
-
 // Exception - no type
 test(function (): void {
 	Assert::exception(function (): void {
-		new RequestParameter([
-			'name' => 'Param',
-		]);
-	}, AnnotationException::class, 'No @RequestParameter type given');
-
-	Assert::exception(function (): void {
-		new RequestParameter([
-			'name' => 'Param',
-			'type' => '',
-		]);
+		new RequestParameter('Param', '');
 	}, AnnotationException::class, 'Empty @RequestParameter type given');
 });

--- a/tests/cases/Annotation/Controller/RequestParameters.phpt
+++ b/tests/cases/Annotation/Controller/RequestParameters.phpt
@@ -15,20 +15,9 @@ use Tester\Assert;
 // OK
 test(function (): void {
 	$parameters = new RequestParameters([
-		'value' => [
-			$parameter1 = new RequestParameter([
-				'name' => 'foo',
-				'type' => EndpointParameter::TYPE_STRING,
-			]),
-			$parameter2 = new RequestParameter([
-				'name' => 'bar',
-				'type' => EndpointParameter::TYPE_STRING,
-			]),
-			$parameter3 = new RequestParameter([
-				'name' => 'baz',
-				'type' => EndpointParameter::TYPE_STRING,
-			]),
-		],
+		$parameter1 = new RequestParameter('foo', EndpointParameter::TYPE_STRING),
+		$parameter2 = new RequestParameter('bar', EndpointParameter::TYPE_STRING),
+		$parameter3 = new RequestParameter('baz', EndpointParameter::TYPE_STRING),
 	]);
 
 	Assert::same([$parameter1, $parameter2, $parameter3], $parameters->getParameters());
@@ -38,12 +27,6 @@ test(function (): void {
 test(function (): void {
 	Assert::exception(function (): void {
 		new RequestParameters([]);
-	}, AnnotationException::class, 'No @RequestParameter given in @RequestParameters');
-
-	Assert::exception(function (): void {
-		new RequestParameters([
-			'value' => [],
-		]);
 	}, AnnotationException::class, 'Empty @RequestParameters given');
 });
 
@@ -51,20 +34,28 @@ test(function (): void {
 test(function (): void {
 	Assert::exception(
 		function (): void {
-			new RequestParameters([
-				'value' => [
-					$parameter1 = new RequestParameter([
-						'name' => 'foo',
-						'type' => EndpointParameter::TYPE_STRING,
-						'in' => EndpointParameter::IN_QUERY,
-					]),
-					$parameter2 = new RequestParameter([
-						'name' => 'foo',
-						'type' => EndpointParameter::TYPE_INTEGER,
-						'in' => EndpointParameter::IN_QUERY,
-					]),
-				],
-			]);
+			new RequestParameters(
+				[
+					$parameter1 = new RequestParameter(
+						'foo',
+						EndpointParameter::TYPE_STRING,
+						false,
+						false,
+						false,
+						null,
+						EndpointParameter::IN_QUERY
+					),
+					$parameter2 = new RequestParameter(
+						'foo',
+						EndpointParameter::TYPE_INTEGER,
+						false,
+						false,
+						false,
+						null,
+						EndpointParameter::IN_QUERY
+					),
+				]
+			);
 		},
 		AnnotationException::class,
 		'Multiple @RequestParameter annotations with "name=foo" and "in=query" given. Each parameter must have unique combination of location and name.'

--- a/tests/cases/Annotation/Controller/RequestParameters.phpt
+++ b/tests/cases/Annotation/Controller/RequestParameters.phpt
@@ -46,8 +46,7 @@ test(function (): void {
 					EndpointParameter::TYPE_INTEGER,
 					EndpointParameter::IN_QUERY,
 					false
-				)]
-			);
+				)]);
 		},
 		AnnotationException::class,
 		'Multiple @RequestParameter annotations with "name=foo" and "in=query" given. Each parameter must have unique combination of location and name.'

--- a/tests/cases/Annotation/Controller/RequestParameters.phpt
+++ b/tests/cases/Annotation/Controller/RequestParameters.phpt
@@ -15,9 +15,9 @@ use Tester\Assert;
 // OK
 test(function (): void {
 	$parameters = new RequestParameters([
-		$parameter1 = new RequestParameter('foo', EndpointParameter::TYPE_STRING),
-		$parameter2 = new RequestParameter('bar', EndpointParameter::TYPE_STRING),
-		$parameter3 = new RequestParameter('baz', EndpointParameter::TYPE_STRING),
+		$parameter1 = new RequestParameter('foo', EndpointParameter::TYPE_STRING, EndpointParameter::IN_PATH),
+		$parameter2 = new RequestParameter('bar', EndpointParameter::TYPE_STRING, EndpointParameter::IN_PATH),
+		$parameter3 = new RequestParameter('baz', EndpointParameter::TYPE_STRING, EndpointParameter::IN_PATH),
 	]);
 
 	Assert::same([$parameter1, $parameter2, $parameter3], $parameters->getParameters());
@@ -34,27 +34,19 @@ test(function (): void {
 test(function (): void {
 	Assert::exception(
 		function (): void {
-			new RequestParameters(
-				[
-					$parameter1 = new RequestParameter(
-						'foo',
-						EndpointParameter::TYPE_STRING,
-						false,
-						false,
-						false,
-						null,
-						EndpointParameter::IN_QUERY
-					),
-					$parameter2 = new RequestParameter(
-						'foo',
-						EndpointParameter::TYPE_INTEGER,
-						false,
-						false,
-						false,
-						null,
-						EndpointParameter::IN_QUERY
-					),
-				]
+			new RequestParameters([
+				$parameter1 = new RequestParameter(
+					'foo',
+					EndpointParameter::TYPE_STRING,
+					EndpointParameter::IN_QUERY,
+					false
+				),
+				$parameter2 = new RequestParameter(
+					'foo',
+					EndpointParameter::TYPE_INTEGER,
+					EndpointParameter::IN_QUERY,
+					false
+				)]
 			);
 		},
 		AnnotationException::class,

--- a/tests/cases/Annotation/Controller/Tag.phpt
+++ b/tests/cases/Annotation/Controller/Tag.phpt
@@ -12,10 +12,7 @@ use Tester\Assert;
 
 // OK
 test(function (): void {
-	$tag = new Tag([
-		'name' => 'name',
-		'value' => null,
-	]);
+	$tag = new Tag('name', null);
 
 	Assert::same('name', $tag->getName());
 	Assert::same(null, $tag->getValue());
@@ -24,15 +21,6 @@ test(function (): void {
 // Exception - empty name
 test(function (): void {
 	Assert::exception(function (): void {
-		new Tag([
-			'value' => null,
-		]);
-	}, AnnotationException::class, 'No @Tag name given');
-
-	Assert::exception(function (): void {
-		new Tag([
-			'name' => '',
-			'value' => null,
-		]);
+		new Tag('', null);
 	}, AnnotationException::class, 'Empty @Tag name given');
 });


### PR DESCRIPTION
Just making use of `@NamedArgumentConstructor` annotation: https://github.com/doctrine/annotations/blob/1.11.x/docs/en/custom.rst#optional-constructors-with-named-parameters

This will make https://github.com/apitte/core/pull/161 much easier to add :+1:  **Merge this PR befor that one**

<br>

I found it by miracle today in here :) 
https://github.com/koriym/Koriym.Attributes#compatible-annotation