### PR TITLE
[PHP 8] Fixup attributes features based on use in practise

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -23,7 +23,9 @@
 	</rule>
 
 	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse">
+		<!-- false positive; slevomat ignores attribute class names and removes their imports -->
 		<exclude-pattern>tests/fixtures/Controllers/AttributeFoobarController.php</exclude-pattern>
+		<exclude-pattern>tests/fixtures/Controllers/AttributeMultiController.php</exclude-pattern>
 	</rule>
 
 	<rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">

--- a/src/Annotation/Controller/Negotiation.php
+++ b/src/Annotation/Controller/Negotiation.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Annotations\Annotation\Target;
  * @Target("ANNOTATION")
  * @NamedArgumentConstructor()
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Negotiation
 {
 

--- a/src/Annotation/Controller/RequestParameter.php
+++ b/src/Annotation/Controller/RequestParameter.php
@@ -12,7 +12,7 @@ use Doctrine\Common\Annotations\AnnotationException;
  * @Target("ANNOTATION")
  * @NamedArgumentConstructor()
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class RequestParameter
 {
 

--- a/src/Annotation/Controller/Response.php
+++ b/src/Annotation/Controller/Response.php
@@ -12,7 +12,7 @@ use Doctrine\Common\Annotations\AnnotationException;
  * @Target("ANNOTATION")
  * @NamedArgumentConstructor()
  */
-#[Attribute(Attribute::TARGET_CLASS)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Response
 {
 

--- a/src/Annotation/Controller/Tag.php
+++ b/src/Annotation/Controller/Tag.php
@@ -12,7 +12,7 @@ use Doctrine\Common\Annotations\AnnotationException;
  * @Target({"CLASS", "METHOD"})
  * @NamedArgumentConstructor()
  */
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Tag
 {
 

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -313,6 +313,7 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 	private function addNegotiationToSchemaMethod(SchemaMethod $schemaMethod, Negotiation $negotiation): void
 	{
 		$endpointNegotiation = $schemaMethod->addNegotiation($negotiation->getSuffix());
+
 		$endpointNegotiation->setDefault($negotiation->isDefault());
 		$endpointNegotiation->setRenderer($negotiation->getRenderer());
 	}
@@ -320,6 +321,7 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 	private function addResponseToSchemaMethod(SchemaMethod $schemaMethod, Response $response): void
 	{
 		$endpointResponse = $schemaMethod->addResponse($response->getCode(), $response->getDescription());
+
 		$endpointResponse->setEntity($response->getEntity());
 	}
 

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -301,13 +301,13 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 	private function addEndpointParameterToSchemaMethod(SchemaMethod $schemaMethod, RequestParameter $requestParameter): void
 	{
-		$parameter = $schemaMethod->addParameter($requestParameter->getName(), $requestParameter->getType());
+		$endpointParameter = $schemaMethod->addParameter($requestParameter->getName(), $requestParameter->getType());
 
-		$parameter->setDescription($requestParameter->getDescription());
-		$parameter->setIn($requestParameter->getIn());
-		$parameter->setRequired($requestParameter->isRequired());
-		$parameter->setDeprecated($requestParameter->isDeprecated());
-		$parameter->setAllowEmpty($requestParameter->isAllowEmpty());
+		$endpointParameter->setDescription($requestParameter->getDescription());
+		$endpointParameter->setIn($requestParameter->getIn());
+		$endpointParameter->setRequired($requestParameter->isRequired());
+		$endpointParameter->setDeprecated($requestParameter->isDeprecated());
+		$endpointParameter->setAllowEmpty($requestParameter->isAllowEmpty());
 	}
 
 	private function addNegotiationToSchemaMethod(SchemaMethod $schemaMethod, Negotiation $negotiation): void

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -17,6 +17,7 @@ use Apitte\Core\Annotation\Controller\Tag;
 use Apitte\Core\DI\LoaderFactory\DualReaderFactory;
 use Apitte\Core\Exception\Logical\InvalidStateException;
 use Apitte\Core\Schema\Builder\Controller\Controller;
+use Apitte\Core\Schema\Builder\Controller\Method as SchemaMethod;
 use Apitte\Core\Schema\EndpointRequestBody;
 use Apitte\Core\Schema\SchemaBuilder;
 use Apitte\Core\UI\Controller\IController;
@@ -227,13 +228,8 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 				// Parse @RequestParameters ================
 				if ($annotation instanceof RequestParameters) {
-					foreach ($annotation->getParameters() as $p) {
-						$parameter = $schemaMethod->addParameter($p->getName(), $p->getType());
-						$parameter->setDescription($p->getDescription());
-						$parameter->setIn($p->getIn());
-						$parameter->setRequired($p->isRequired());
-						$parameter->setDeprecated($p->isDeprecated());
-						$parameter->setAllowEmpty($p->isAllowEmpty());
+					foreach ($annotation->getParameters() as $parameter) {
+						$this->addEndpointParameterToSchemaMethod($schemaMethod, $parameter);
 					}
 
 					continue;
@@ -241,12 +237,7 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 				// Parse #[RequestParameter] ================
 				if ($annotation instanceof RequestParameter) {
-					$parameter = $schemaMethod->addParameter($annotation->getName(), $annotation->getType());
-					$parameter->setDescription($annotation->getDescription());
-					$parameter->setIn($annotation->getIn());
-					$parameter->setRequired($annotation->isRequired());
-					$parameter->setDeprecated($annotation->isDeprecated());
-					$parameter->setAllowEmpty($annotation->isAllowEmpty());
+					$this->addEndpointParameterToSchemaMethod($schemaMethod, $annotation);
 
 					continue;
 				}
@@ -312,6 +303,17 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 		}
 
 		return $this->reader;
+	}
+
+	private function addEndpointParameterToSchemaMethod(SchemaMethod $schemaMethod, RequestParameter $requestParameter): void
+	{
+		$parameter = $schemaMethod->addParameter($requestParameter->getName(), $requestParameter->getType());
+
+		$parameter->setDescription($requestParameter->getDescription());
+		$parameter->setIn($requestParameter->getIn());
+		$parameter->setRequired($requestParameter->isRequired());
+		$parameter->setDeprecated($requestParameter->isDeprecated());
+		$parameter->setAllowEmpty($requestParameter->isAllowEmpty());
 	}
 
 }

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -244,9 +244,8 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 				// Parse @Responses ================
 				if ($annotation instanceof Responses) {
-					foreach ($annotation->getResponses() as $r) {
-						$response = $schemaMethod->addResponse($r->getCode(), $r->getDescription());
-						$response->setEntity($r->getEntity());
+					foreach ($annotation->getResponses() as $response) {
+						$this->addResponseToSchemaMethod($schemaMethod, $response);
 					}
 
 					continue;
@@ -254,8 +253,7 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 				// Parse #[Response] attribute
 				if ($annotation instanceof Response) {
-					$response = $schemaMethod->addResponse($annotation->getCode(), $annotation->getDescription());
-					$response->setEntity($annotation->getEntity());
+					$this->addResponseToSchemaMethod($schemaMethod, $annotation);
 					continue;
 				}
 
@@ -317,6 +315,12 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 		$endpointNegotiation = $schemaMethod->addNegotiation($negotiation->getSuffix());
 		$endpointNegotiation->setDefault($negotiation->isDefault());
 		$endpointNegotiation->setRenderer($negotiation->getRenderer());
+	}
+
+	private function addResponseToSchemaMethod(SchemaMethod $schemaMethod, Response $response): void
+	{
+		$endpointResponse = $schemaMethod->addResponse($response->getCode(), $response->getDescription());
+		$endpointResponse->setEntity($response->getEntity());
 	}
 
 }

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -238,7 +238,6 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 				// Parse #[RequestParameter] ================
 				if ($annotation instanceof RequestParameter) {
 					$this->addEndpointParameterToSchemaMethod($schemaMethod, $annotation);
-
 					continue;
 				}
 

--- a/src/DI/Loader/DoctrineAnnotationLoader.php
+++ b/src/DI/Loader/DoctrineAnnotationLoader.php
@@ -278,18 +278,14 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 
 				// Parse @Negotiations =====================
 				if ($annotation instanceof Negotiations) {
-					foreach ($annotation->getNegotiations() as $n) {
-						$negotiation = $schemaMethod->addNegotiation($n->getSuffix());
-						$negotiation->setDefault($n->isDefault());
-						$negotiation->setRenderer($n->getRenderer());
+					foreach ($annotation->getNegotiations() as $negotiation) {
+						$this->addNegotiationToSchemaMethod($schemaMethod, $negotiation);
 					}
 				}
 
 				// Parse #[Negotiation] =====================
 				if ($annotation instanceof Negotiation) {
-					$negotiation = $schemaMethod->addNegotiation($annotation->getSuffix());
-					$negotiation->setDefault($annotation->isDefault());
-					$negotiation->setRenderer($annotation->getRenderer());
+					$this->addNegotiationToSchemaMethod($schemaMethod, $annotation);
 				}
 			}
 		}
@@ -314,6 +310,13 @@ final class DoctrineAnnotationLoader extends AbstractContainerLoader
 		$parameter->setRequired($requestParameter->isRequired());
 		$parameter->setDeprecated($requestParameter->isDeprecated());
 		$parameter->setAllowEmpty($requestParameter->isAllowEmpty());
+	}
+
+	private function addNegotiationToSchemaMethod(SchemaMethod $schemaMethod, Negotiation $negotiation): void
+	{
+		$endpointNegotiation = $schemaMethod->addNegotiation($negotiation->getSuffix());
+		$endpointNegotiation->setDefault($negotiation->isDefault());
+		$endpointNegotiation->setRenderer($negotiation->getRenderer());
 	}
 
 }

--- a/tests/cases/DI/Loader/DoctrineAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineAnnotationLoader.phpt
@@ -60,7 +60,6 @@ test(function (): void {
 	$controllers = $schemaBuilder->getControllers();
 
 	foreach ($controllers as $controller) {
-
 		testController($controller);
 	}
 });

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -34,14 +34,14 @@ test(function (): void {
 	$controllers = $schemaBuilder->getControllers();
 
 	foreach ($controllers as $controller) {
-		testMultiController($controller);
-		testMultiControllerResponses($controller);
-		testMultiControllerRequestParameters($controller);
-		testMultiControllerNegotiations($controller);
+		testTags($controller);
+		testResponses($controller);
+		testRequestParameters($controller);
+		testNegotiations($controller);
 	}
 });
 
-function testMultiController(Controller $controller): void
+function testTags(Controller $controller): void
 {
 	Assert::count(2, $controller->getTags());
 
@@ -52,7 +52,7 @@ function testMultiController(Controller $controller): void
 	Assert::same('no', $secondTagValue);
 }
 
-function testMultiControllerRequestParameters(Controller $controller): void
+function testRequestParameters(Controller $controller): void
 {
 	$requestParametersMethod = $controller->getMethods()['requestParameters'];
 	Assert::equal('requestParameters', $requestParametersMethod->getName());
@@ -73,7 +73,7 @@ function testMultiControllerRequestParameters(Controller $controller): void
 	Assert::null($secondParameter->getDescription());
 }
 
-function testMultiControllerResponses(Controller $controller): void
+function testResponses(Controller $controller): void
 {
 	$responsesMethod = $controller->getMethods()['responses'];
 	Assert::equal('responses', $responsesMethod->getName());
@@ -92,7 +92,7 @@ function testMultiControllerResponses(Controller $controller): void
 	Assert::null($secondResponse->getEntity());
 }
 
-function testMultiControllerNegotiations(Controller $controller): void
+function testNegotiations(Controller $controller): void
 {
 	$negotiationsMethod = $controller->getMethods()['negotiations'];
 	Assert::equal('negotiations', $negotiationsMethod->getName());

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -74,7 +74,17 @@ function testMultiControllerResponses(Controller $controller): void
 	Assert::count(2, $responsesMethod->getResponses());
 
 	$firstResponse = $responsesMethod->getResponses()['cz'];
+
+	Assert::equal('cz', $firstResponse->getCode());
+	Assert::equal('some_description', $firstResponse->getDescription());
+	Assert::null($firstResponse->getEntity());
+
 	$secondResponse = $responsesMethod->getResponses()['com'];
+
+	Assert::equal('com', $secondResponse->getCode());
+	Assert::equal('some_description_2', $secondResponse->getDescription());
+	Assert::null($secondResponse->getEntity());
+
 }
 
 function testMultiControllerNegotiations(Controller $controller): void

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -44,6 +44,12 @@ test(function (): void {
 function testMultiController(Controller $controller): void
 {
 	Assert::count(2, $controller->getTags());
+
+	$firstTagValue = $controller->getTags()['nice'];
+	Assert::same('yes', $firstTagValue);
+
+	$secondTagValue = $controller->getTags()['one'];
+	Assert::same('no', $secondTagValue);
 }
 
 function testMultiControllerRequestParameters(Controller $controller): void

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -84,7 +84,6 @@ function testMultiControllerResponses(Controller $controller): void
 	Assert::equal('com', $secondResponse->getCode());
 	Assert::equal('some_description_2', $secondResponse->getDescription());
 	Assert::null($secondResponse->getEntity());
-
 }
 
 function testMultiControllerNegotiations(Controller $controller): void
@@ -94,5 +93,12 @@ function testMultiControllerNegotiations(Controller $controller): void
 	Assert::count(2, $negotiationsMethod->getNegotiations());
 
 	$firstNegotiation = $negotiationsMethod->getNegotiations()[0];
+
+	Assert::same('some_suffix', $firstNegotiation->getSuffix());
+	Assert::null($firstNegotiation->getRenderer());
+
 	$secondNegotiation = $negotiationsMethod->getNegotiations()[1];
+
+	Assert::same('some_suffix_2', $secondNegotiation->getSuffix());
+	Assert::null($secondNegotiation->getRenderer());
 }

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -53,7 +53,18 @@ function testMultiControllerRequestParameters(Controller $controller): void
 	Assert::count(2, $requestParametersMethod->getParameters());
 
 	$firstParameter = $requestParametersMethod->getParameters()['name_value'];
+
+	Assert::equal('name_value', $firstParameter->getName());
+	Assert::equal('type_value', $firstParameter->getType());
+	Assert::equal('in_value', $firstParameter->getIn());
+	Assert::null($firstParameter->getDescription());
+
 	$secondParameter = $requestParametersMethod->getParameters()['name_value_2'];
+
+	Assert::equal('name_value_2', $secondParameter->getName());
+	Assert::equal('type_value_2', $secondParameter->getType());
+	Assert::equal('in_value_2', $secondParameter->getIn());
+	Assert::null($secondParameter->getDescription());
 }
 
 function testMultiControllerResponses(Controller $controller): void

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -35,22 +35,43 @@ test(function (): void {
 
 	foreach ($controllers as $controller) {
 		testMultiController($controller);
+		testMultiControllerResponses($controller);
+		testMultiControllerRequestParameters($controller);
+		testMultiControllerNegotiations($controller);
 	}
 });
 
 function testMultiController(Controller $controller): void
 {
 	Assert::count(2, $controller->getTags());
+}
 
-	$responsesMethod = $controller->getMethods()['responses'];
-	Assert::equal('responses', $responsesMethod->getName());
-	Assert::count(2, $responsesMethod->getResponses());
-
+function testMultiControllerRequestParameters(Controller $controller): void
+{
 	$requestParametersMethod = $controller->getMethods()['requestParameters'];
 	Assert::equal('requestParameters', $requestParametersMethod->getName());
 	Assert::count(2, $requestParametersMethod->getParameters());
 
+	$firstParameter = $requestParametersMethod->getParameters()['name_value'];
+	$secondParameter = $requestParametersMethod->getParameters()['name_value_2'];
+}
+
+function testMultiControllerResponses(Controller $controller): void
+{
+	$responsesMethod = $controller->getMethods()['responses'];
+	Assert::equal('responses', $responsesMethod->getName());
+	Assert::count(2, $responsesMethod->getResponses());
+
+	$firstResponse = $responsesMethod->getResponses()['cz'];
+	$secondResponse = $responsesMethod->getResponses()['com'];
+}
+
+function testMultiControllerNegotiations(Controller $controller): void
+{
 	$negotiationsMethod = $controller->getMethods()['negotiations'];
 	Assert::equal('negotiations', $negotiationsMethod->getName());
 	Assert::count(2, $negotiationsMethod->getNegotiations());
+
+	$firstNegotiation = $negotiationsMethod->getNegotiations()[0];
+	$secondNegotiation = $negotiationsMethod->getNegotiations()[1];
 }

--- a/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
+++ b/tests/cases/DI/Loader/DoctrineMultiAnnotationLoader.phpt
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Test: DI\Loader\DoctrineAnnotationLoader for multiple annotations of one type
+ */
+
+require_once __DIR__ . '/../../../bootstrap.php';
+
+use Apitte\Core\DI\Loader\DoctrineAnnotationLoader;
+use Apitte\Core\Schema\Builder\Controller\Controller;
+use Apitte\Core\Schema\SchemaBuilder;
+use Nette\DI\ContainerBuilder;
+use Tester\Assert;
+use Tests\Fixtures\Controllers\AnnotationMultiController;
+use Tests\Fixtures\Controllers\AttributeMultiController;
+
+// Parse annotations
+test(function (): void {
+	$builder = new ContainerBuilder();
+	$builder->addDefinition('annotation_multi_controller')
+		->setType(AnnotationMultiController::class);
+
+	// include attribute controller only on PHP 8.0 and up
+	if (PHP_VERSION_ID >= 80000) {
+		$builder->addDefinition('attribute_multi_controller')
+			->setType(AttributeMultiController::class);
+	}
+
+	$loader = new DoctrineAnnotationLoader($builder);
+	$schemaBuilder = $loader->load(new SchemaBuilder());
+
+	Assert::type(SchemaBuilder::class, $schemaBuilder);
+
+	$controllers = $schemaBuilder->getControllers();
+
+	foreach ($controllers as $controller) {
+		testMultiController($controller);
+	}
+});
+
+function testMultiController(Controller $controller): void
+{
+	Assert::count(2, $controller->getTags());
+
+	$responsesMethod = $controller->getMethods()['responses'];
+	Assert::equal('responses', $responsesMethod->getName());
+	Assert::count(2, $responsesMethod->getResponses());
+
+	$requestParametersMethod = $controller->getMethods()['requestParameters'];
+	Assert::equal('requestParameters', $requestParametersMethod->getName());
+	Assert::count(2, $requestParametersMethod->getParameters());
+
+	$negotiationsMethod = $controller->getMethods()['negotiations'];
+	Assert::equal('negotiations', $negotiationsMethod->getName());
+	Assert::count(2, $negotiationsMethod->getNegotiations());
+}

--- a/tests/fixtures/Controllers/AnnotationMultiController.php
+++ b/tests/fixtures/Controllers/AnnotationMultiController.php
@@ -11,8 +11,8 @@ use Apitte\Core\Annotation\Controller\Responses;
 use Apitte\Core\Annotation\Controller\Tag;
 
 /**
- * @Tag("nice")
- * @Tag("one")
+ * @Tag("nice", value="yes")
+ * @Tag("one", value="no")
  */
 final class AnnotationMultiController extends ApiV1Controller
 {

--- a/tests/fixtures/Controllers/AnnotationMultiController.php
+++ b/tests/fixtures/Controllers/AnnotationMultiController.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Controllers;
+
+use Apitte\Core\Annotation\Controller\Negotiation;
+use Apitte\Core\Annotation\Controller\Negotiations;
+use Apitte\Core\Annotation\Controller\RequestParameter;
+use Apitte\Core\Annotation\Controller\RequestParameters;
+use Apitte\Core\Annotation\Controller\Response;
+use Apitte\Core\Annotation\Controller\Responses;
+use Apitte\Core\Annotation\Controller\Tag;
+
+/**
+ * @Tag("nice")
+ * @Tag("one")
+ */
+final class AnnotationMultiController extends ApiV1Controller
+{
+
+	/**
+	 * @Responses({
+	 * 		@Response("some_description", code="cz"),
+	 * 		@Response(description="some_description_2", code="com")
+	 * })
+	 */
+	public function responses(): void
+	{
+	}
+
+	/**
+	 * @RequestParameters({
+	 *		@RequestParameter(name="name_value", type="type_value", in="in_value"),
+	 *		@RequestParameter(in="in_value_2", type="type_value_2", name="name_value_2")
+	 * })
+	 */
+	public function requestParameters(): void
+	{
+	}
+
+	/**
+	 * @Negotiations({
+	 * 		@Negotiation("some_suffix"),
+	 * 		@Negotiation(suffix="some_suffix_2")
+	 * })
+	 */
+	public function negotiations(): void
+	{
+	}
+
+}

--- a/tests/fixtures/Controllers/AttributeMultiController.php
+++ b/tests/fixtures/Controllers/AttributeMultiController.php
@@ -7,8 +7,8 @@ use Apitte\Core\Annotation\Controller\RequestParameter;
 use Apitte\Core\Annotation\Controller\Response;
 use Apitte\Core\Annotation\Controller\Tag;
 
-#[Tag('nice')]
-#[Tag('one')]
+#[Tag('nice', value: 'yes')]
+#[Tag('one', value: 'no')]
 final class AttributeMultiController extends ApiV1Controller
 {
 

--- a/tests/fixtures/Controllers/AttributeMultiController.php
+++ b/tests/fixtures/Controllers/AttributeMultiController.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Tests\Fixtures\Controllers;
+
+use Apitte\Core\Annotation\Controller\Negotiation;
+use Apitte\Core\Annotation\Controller\RequestParameter;
+use Apitte\Core\Annotation\Controller\Response;
+use Apitte\Core\Annotation\Controller\Tag;
+
+#[Tag('nice')]
+#[Tag('one')]
+final class AttributeMultiController extends ApiV1Controller
+{
+
+	#[Response('some_description', code: 'cz')]
+	#[Response(description: 'some_description_2', code: 'com')]
+	public function responses(): void
+	{
+	}
+
+	#[RequestParameter(name: 'name_value', type: 'type_value', in: 'in_value')]
+	#[RequestParameter(in: 'in_value_2', type: 'type_value_2', name: 'name_value_2')]
+	public function requestParameters(): void
+	{
+	}
+
+	#[Negotiation('some_suffix')]
+	#[Negotiation(suffix: 'some_suffix_2')]
+	public function negotiations(): void
+	{
+	}
+
+}


### PR DESCRIPTION
This fixes previously nested annotation, that are now attributes that were not parsed correctly:

```php
class SomeController
{

	#[Response('some_description', code: 'cz')]
	#[Response(description: 'some_description_2', code: 'com')]
	public function responses(): void
	{
	}

	#[RequestParameter(name: 'name_value', type: 'type_value', in: 'in_value')]
	#[RequestParameter(in: 'in_value_2', type: 'type_value_2', name: 'name_value_2')]
	public function requestParameters(): void
	{
	}

	#[Negotiation('some_suffix')]
	#[Negotiation(suffix: 'some_suffix_2')]
	public function negotiations(): void
	{
	}

}
```



Follow up to https://github.com/apitte/core/pull/161
