### PR TITLE
Added support for HEAD method

### DIFF
--- a/src/Mapping/Request/BasicEntity.php
+++ b/src/Mapping/Request/BasicEntity.php
@@ -28,7 +28,7 @@ abstract class BasicEntity extends AbstractEntity
 			return $this->fromBodyRequest($request);
 		}
 
-		if (in_array($request->getMethod(), [Endpoint::METHOD_GET, Endpoint::METHOD_DELETE], true)) {
+		if (in_array($request->getMethod(), [Endpoint::METHOD_GET, Endpoint::METHOD_DELETE, Endpoint::METHOD_HEAD], true)) {
 			return $this->fromGetRequest($request);
 		}
 

--- a/src/Schema/Endpoint.php
+++ b/src/Schema/Endpoint.php
@@ -16,6 +16,7 @@ final class Endpoint
 	public const METHOD_DELETE = 'DELETE';
 	public const METHOD_OPTIONS = 'OPTIONS';
 	public const METHOD_PATCH = 'PATCH';
+	public const METHOD_HEAD = 'HEAD';
 
 	public const METHODS = [
 		self::METHOD_GET,
@@ -24,6 +25,7 @@ final class Endpoint
 		self::METHOD_DELETE,
 		self::METHOD_OPTIONS,
 		self::METHOD_PATCH,
+		self::METHOD_HEAD,
 	];
 
 	// Tags

--- a/src/Schema/Validation/FullpathValidation.php
+++ b/src/Schema/Validation/FullpathValidation.php
@@ -27,6 +27,7 @@ class FullpathValidation implements IValidation
 			Endpoint::METHOD_DELETE => [],
 			Endpoint::METHOD_OPTIONS => [],
 			Endpoint::METHOD_PATCH => [],
+			Endpoint::METHOD_HEAD => [],
 		];
 
 		foreach ($controllers as $controller) {

--- a/tests/cases/Mapping/RequestEntityMapping.phpt
+++ b/tests/cases/Mapping/RequestEntityMapping.phpt
@@ -93,7 +93,7 @@ test(function (): void {
 	$bodyRequest = $request
 		->withBody(Utils::streamFor(json_encode(['foo' => 1])));
 
-	foreach ([Endpoint::METHOD_GET, Endpoint::METHOD_DELETE] as $method) {
+	foreach ([Endpoint::METHOD_GET, Endpoint::METHOD_DELETE, Endpoint::METHOD_HEAD] as $method) {
 		$entity = $entity->fromRequest($queryRequest->withMethod($method));
 
 		Assert::same(1, $entity->foo);

--- a/tests/cases/Schema/SchemaBuilderTest.php
+++ b/tests/cases/Schema/SchemaBuilderTest.php
@@ -75,7 +75,7 @@ class SchemaBuilderTest extends TestCase
 		Assert::same('PUT, PATCH /users/{id}', $this->buildPath($endpoints[3]));
 		Assert::same('GET /users', $this->buildPath($endpoints[4]));
 		Assert::same('GET /{id}/users', $this->buildPath($endpoints[5]));
-		Assert::same('GET, POST, PUT, DELETE, OPTIONS, PATCH /', $this->buildPath($endpoints[6]));
+		Assert::same('GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD /', $this->buildPath($endpoints[6]));
 	}
 
 	private function addGetUsersSomethingEndpoint(SchemaBuilder $builder): void


### PR DESCRIPTION
Hi,
I saw in the documentation that the HEAD method is supported (https://github.com/apitte/core/blob/master/.docs/endpoints.md#list-of-annotations--attributes `@Method`).
However, it isn't currently supported :)
