### PR TITLE
CI: inherit secrets in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
## What changed
- added `secrets: inherit` to the reusable coverage workflow job

## Why
- ensures the coverage workflow receives the same secrets as the caller, resolving contributte/contributte#74

contributte/contributte#74
